### PR TITLE
feat(ui): :sparkles: add auto-accept countdown timer to config panels

### DIFF
--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from mxbiflow import set_base_path
+from mxbiflow.bootstrap import init_gameloop
+from mxbiflow.scene import SceneManager
+from mxbiflow.scene.idle.idle import IDLE
+from mxbiflow.ui.wizard import config_wizard
+
+
+def main() -> None:
+    set_base_path(Path.cwd())
+
+    scene_manager = SceneManager()
+    scene_manager.register([IDLE])
+
+    config_wizard(scene_manager)
+
+    game = init_gameloop(scene_manager)
+    game.play()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mxbiflow/core/path.py
+++ b/src/mxbiflow/core/path.py
@@ -5,6 +5,7 @@ _base_path: Path | None = None
 CONFIG_SESSION_FILENAME = "session.json"
 OPTIONS_SESSION_FILENAME = "options.json"
 MXBI_CONFIG_FILENAME = "mxbi.json"
+MXBI_PANEL_CONFIG_FILENAME = "mxbi_panel.json"
 CROSS_MODAL_CONFIG_FILENAME = "config_cross_modal.json"
 SAMBA_BACKUP_DIR_NAME = "backup"
 SERVICE_DIR_NAME = "services"
@@ -29,6 +30,10 @@ def get_config_dir_path() -> Path:
 
 def get_mxbi_config_path() -> Path:
     return get_config_dir_path() / MXBI_CONFIG_FILENAME
+
+
+def get_mxbi_panel_config_path() -> Path:
+    return get_config_dir_path() / MXBI_PANEL_CONFIG_FILENAME
 
 
 def get_config_session_path() -> Path:

--- a/src/mxbiflow/models/panel.py
+++ b/src/mxbiflow/models/panel.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel, Field
+
+
+class MXBIPanelConfig(BaseModel):
+    auto_accept_timeout_seconds: int = Field(default=60, ge=0)

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -24,6 +24,8 @@ class SessionConfig(BaseModel):
     hide_cursor: bool = Field(default=False)
     fullscreen: bool = Field(default=False)
 
+    auto_accept_timeout_seconds: int = Field(default=60, ge=0)
+
     animals: list[AnimalConfig] = Field(default_factory=list)
 
 

--- a/src/mxbiflow/ui/components/baseconfig.py
+++ b/src/mxbiflow/ui/components/baseconfig.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pymxbi import MXBIModel
 from pymxbi.screen import get_screen_size
 from PySide6.QtCore import Signal
-from PySide6.QtWidgets import QComboBox, QFormLayout, QGroupBox, QLabel
+from PySide6.QtWidgets import QComboBox, QFormLayout, QGroupBox, QLabel, QSpinBox
 
 
 class BaseConfig(QGroupBox):
@@ -31,6 +31,12 @@ class BaseConfig(QGroupBox):
             )
         self._layout.addRow(self._label_screen, self._combo_screen)
 
+        self._label_auto_accept = QLabel("auto accept (s):")
+        self._spin_auto_accept = QSpinBox()
+        self._spin_auto_accept.setRange(0, 3600)
+        self._spin_auto_accept.setSpecialValueText("Disabled")
+        self._layout.addRow(self._label_auto_accept, self._spin_auto_accept)
+
         self._bind_events()
 
     def _emit_changed(self, msg: str) -> None:
@@ -39,6 +45,9 @@ class BaseConfig(QGroupBox):
     def _bind_events(self) -> None:
         self._combo_mxbi.currentTextChanged.connect(self._emit_changed)
         self._combo_screen.currentTextChanged.connect(self._emit_changed)
+        self._spin_auto_accept.valueChanged.connect(
+            lambda v: self._emit_changed(f"auto_accept:{v}")
+        )
 
     @property
     def mxbi_id(self) -> str:
@@ -48,6 +57,10 @@ class BaseConfig(QGroupBox):
     def screen_size(self) -> tuple[int, int]:
         return self._combo_screen.currentData()
 
+    @property
+    def auto_accept_timeout(self) -> int:
+        return self._spin_auto_accept.value()
+
     def load_from_model(self, model: MXBIModel) -> None:
         self._combo_mxbi.setCurrentText(model.mxbi_id)
         for i in range(self._combo_screen.count()):
@@ -55,11 +68,9 @@ class BaseConfig(QGroupBox):
                 self._combo_screen.setCurrentIndex(i)
                 break
 
-    def apply_to_model(self, model: MXBIModel) -> None:
-        mxbi_id_text = self._combo_mxbi.currentText().strip()
-        try:
-            model.mxbi_id = int(mxbi_id_text) if mxbi_id_text else 0
-        except ValueError:
-            model.mxbi_id = 0
+    def load_auto_accept_timeout(self, timeout_seconds: int) -> None:
+        self._spin_auto_accept.setValue(timeout_seconds)
 
+    def apply_to_model(self, model: MXBIModel) -> None:
+        model.mxbi_id = self.mxbi_id
         model.screen_size = self._combo_screen.currentData()

--- a/src/mxbiflow/ui/components/countdown.py
+++ b/src/mxbiflow/ui/components/countdown.py
@@ -1,0 +1,74 @@
+from PySide6.QtCore import QTimer, Signal
+from PySide6.QtWidgets import QHBoxLayout, QLabel, QWidget
+
+
+class AutoAcceptCountdown(QWidget):
+    timeout = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._remaining_seconds = 0
+        self._is_paused = False
+        self._is_active = False
+
+        self._timer = QTimer(self)
+        self._timer.setInterval(1000)
+        self._timer.timeout.connect(self._tick)
+
+        layout = QHBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        self._label = QLabel("", self)
+        self._label.setStyleSheet("color: #4CAF50; font-weight: bold;")
+        layout.addWidget(self._label)
+
+        self.hide()
+
+    def start(self, seconds: int) -> None:
+        if seconds <= 0:
+            self.stop()
+            return
+
+        self._remaining_seconds = seconds
+        self._is_paused = False
+        self._is_active = True
+        self._update_label()
+        self.show()
+        self._timer.start()
+
+    def pause(self) -> None:
+        if not self._is_active or self._is_paused:
+            return
+
+        self._is_paused = True
+        self._timer.stop()
+        self._update_label()
+
+    def stop(self) -> None:
+        self._timer.stop()
+        self._is_paused = False
+        self._is_active = False
+        self._remaining_seconds = 0
+        self.hide()
+
+    def is_active(self) -> bool:
+        return self._is_active and not self._is_paused
+
+    def _tick(self) -> None:
+        self._remaining_seconds -= 1
+        if self._remaining_seconds <= 0:
+            self._timer.stop()
+            self._is_active = False
+            self.hide()
+            self.timeout.emit()
+        else:
+            self._update_label()
+
+    def _update_label(self) -> None:
+        if self._is_paused:
+            self._label.setText(f"Paused: {self._remaining_seconds}s")
+            self._label.setStyleSheet("color: #9E9E9E; font-weight: bold;")
+        else:
+            self._label.setText(f"Auto: {self._remaining_seconds}s")
+            self._label.setStyleSheet("color: #4CAF50; font-weight: bold;")

--- a/src/mxbiflow/ui/components/experiment_groups.py
+++ b/src/mxbiflow/ui/components/experiment_groups.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QMenu,
+    QSpinBox,
 )
 
 from ...models.animal import AnimalConfig
@@ -26,7 +27,6 @@ class ExperimentConfigGroup(QGroupBox):
         layout.setColumnStretch(1, 1)
         layout.setColumnStretch(3, 1)
 
-        # Row 0: experimenter | hide cursor
         layout.addWidget(QLabel("experimenter", self), 0, 0)
         self.combo_experimenter = QComboBox(self)
         self.combo_experimenter.addItems(experimenters)
@@ -36,7 +36,6 @@ class ExperimentConfigGroup(QGroupBox):
         self.check_hide_cursor = QCheckBox(self)
         layout.addWidget(self.check_hide_cursor, 0, 3)
 
-        # Row 1: reward type | fullscreen
         layout.addWidget(QLabel("reward type", self), 1, 0)
         self.combo_reward_type = QComboBox(self)
         self.combo_reward_type.addItems(list(RewardEnum))
@@ -46,17 +45,23 @@ class ExperimentConfigGroup(QGroupBox):
         self.check_fullscreen = QCheckBox(self)
         layout.addWidget(self.check_fullscreen, 1, 3)
 
-        # Row 2: notes (span all columns)
         layout.addWidget(QLabel("notes", self), 2, 0)
         self.line_notes = QLineEdit(self)
         self.line_notes.setPlaceholderText("Notes")
         layout.addWidget(self.line_notes, 2, 1, 1, 3)
+
+        layout.addWidget(QLabel("auto accept (s)", self), 3, 0)
+        self.spin_auto_accept = QSpinBox(self)
+        self.spin_auto_accept.setRange(0, 3600)
+        self.spin_auto_accept.setSpecialValueText("Disabled")
+        layout.addWidget(self.spin_auto_accept, 3, 1)
 
     def load_config(self, config: SessionConfig):
         self.combo_experimenter.setEditText(config.experimenter)
         self.combo_reward_type.setEditText(config.reward_type)
         self.check_hide_cursor.setChecked(config.hide_cursor)
         self.check_fullscreen.setChecked(config.fullscreen)
+        self.spin_auto_accept.setValue(config.auto_accept_timeout_seconds)
 
     def result(self) -> SessionConfig:
         return SessionConfig(
@@ -65,6 +70,7 @@ class ExperimentConfigGroup(QGroupBox):
             note=self.line_notes.text(),
             hide_cursor=self.check_hide_cursor.isChecked(),
             fullscreen=self.check_fullscreen.isChecked(),
+            auto_accept_timeout_seconds=self.spin_auto_accept.value(),
         )
 
 

--- a/src/mxbiflow/ui/experiment_panel.py
+++ b/src/mxbiflow/ui/experiment_panel.py
@@ -1,6 +1,6 @@
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QEvent, Qt, Signal
 from PySide6.QtWidgets import (
-    QHBoxLayout,
+    QGridLayout,
     QMainWindow,
     QPushButton,
     QVBoxLayout,
@@ -11,6 +11,7 @@ from ..core.config_store import ConfigStore
 from ..core.path import get_config_session_path, get_options_session_path
 from ..models.session import Options, SessionConfig
 from ..scene import SceneManager
+from .components.countdown import AutoAcceptCountdown
 from .components.experiment_groups import (
     ExperimentAnimalsGroup,
     ExperimentConfigGroup,
@@ -58,22 +59,43 @@ class ExperimentPanel(QMainWindow):
         self.combo_reward_type = self.group_config.combo_reward_type
         self.line_notes = self.group_config.line_notes
 
-        layout_buttons = QHBoxLayout(self)
+        layout_buttons = QGridLayout(self)
         layout_main.addLayout(layout_buttons)
-        self._button_cancle = QPushButton("Cancel", self)
+
+        self._countdown = AutoAcceptCountdown(self)
+        self._button_cancel = QPushButton("Cancel", self)
         self._button_save = QPushButton("Save", self)
         self._button_continue = QPushButton("Continue", self)
-        layout_buttons.addWidget(self._button_cancle)
-        layout_buttons.addWidget(self._button_save)
-        layout_buttons.addWidget(self._button_continue)
+
+        layout_buttons.addWidget(
+            self._countdown, 0, 2, alignment=Qt.AlignmentFlag.AlignRight
+        )
+        layout_buttons.addWidget(self._button_cancel, 1, 0)
+        layout_buttons.addWidget(self._button_save, 1, 1)
+        layout_buttons.addWidget(self._button_continue, 1, 2)
 
         self._bind_signals()
         self.load_config()
+        self._start_auto_accept_countdown()
 
     def _bind_signals(self):
-        self._button_cancle.clicked.connect(self._on_cancle)
+        self._button_cancel.clicked.connect(self._on_cancel)
         self._button_save.clicked.connect(self._on_save)
         self._button_continue.clicked.connect(self._on_continue)
+
+        self._button_cancel.clicked.connect(self._countdown.stop)
+        self._button_save.clicked.connect(self._countdown.stop)
+        self._button_continue.clicked.connect(self._countdown.stop)
+
+        self.centralWidget().installEventFilter(self)
+
+    def _on_user_interaction(self, _=None) -> None:
+        self._countdown.pause()
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Type.MouseButtonPress:
+            self._countdown.pause()
+        return super().eventFilter(obj, event)
 
     def load_config(self):
         self.group_config.load_config(self._config.value)
@@ -92,7 +114,7 @@ class ExperimentPanel(QMainWindow):
     def _on_save(self):
         self._config.save(self.result())
 
-    def _on_cancle(self):
+    def _on_cancel(self):
         self.close()
 
     def _on_continue(self):
@@ -100,6 +122,12 @@ class ExperimentPanel(QMainWindow):
         self._accepted = True
         self.close()
         self.accepted.emit()
+
+    def _start_auto_accept_countdown(self) -> None:
+        timeout = self._config.value.auto_accept_timeout_seconds
+        if timeout > 0:
+            self._countdown.start(timeout)
+            self._countdown.timeout.connect(self._on_continue)
 
     def closeEvent(self, event) -> None:
         super().closeEvent(event)

--- a/src/mxbiflow/ui/mxbi_panel.py
+++ b/src/mxbiflow/ui/mxbi_panel.py
@@ -1,9 +1,9 @@
 from pymxbi import MXBIModel
 from pymxbi.detector import DetectorEnum, DetectorModel
 from pymxbi.rewarder import RewarderEnum, RewarderModel
-from PySide6.QtCore import Signal
+from PySide6.QtCore import QEvent, Qt, Signal
 from PySide6.QtWidgets import (
-    QHBoxLayout,
+    QGridLayout,
     QMainWindow,
     QPushButton,
     QVBoxLayout,
@@ -11,9 +11,15 @@ from PySide6.QtWidgets import (
 )
 
 from ..core.config_store import ConfigStore
-from ..core.path import get_mxbi_config_path, get_options_session_path
+from ..core.path import (
+    get_mxbi_config_path,
+    get_mxbi_panel_config_path,
+    get_options_session_path,
+)
+from ..models.panel import MXBIPanelConfig
 from ..models.session import Options
 from .components.baseconfig import BaseConfig
+from .components.countdown import AutoAcceptCountdown
 from .components.device_card import (
     BeambreakDetectorCard,
     FusionDetectorCard,
@@ -40,23 +46,17 @@ class MXBIPanel(QMainWindow):
         DetectorEnum.MOCK: MockDetectorCard,
     }
 
-    # -----------------------------
-    # Lifecycle / Init
-    # -----------------------------
-
     def __init__(self):
         super().__init__()
         self._accepted = False
         self._config = ConfigStore(get_mxbi_config_path(), MXBIModel)
         self._options = ConfigStore(get_options_session_path(), Options)
+        self._panel_config = ConfigStore(get_mxbi_panel_config_path(), MXBIPanelConfig)
 
         self._build_ui()
         self._load_from_config()
         self._bind_events()
-
-    # -----------------------------
-    # UI Construction
-    # -----------------------------
+        self._start_auto_accept_countdown()
 
     def _build_ui(self) -> None:
         self.setWindowTitle("MXBI Configuration Panel")
@@ -69,7 +69,7 @@ class MXBIPanel(QMainWindow):
         self.base_config = BaseConfig(self, self._options.value.mxbis)
         self._layout_main.addWidget(self.base_config)
         self._build_device_groups()
-        self._layout_main.addLayout(self._build_buttons_row())
+        self._layout_main.addLayout(self._build_buttons_layout())
 
     def _build_device_groups(self) -> None:
         self.rewarders_group = Devices[RewarderModel](
@@ -96,22 +96,26 @@ class MXBIPanel(QMainWindow):
         )
         self._layout_main.addWidget(self.detectors_group)
 
-    def _build_buttons_row(self) -> QHBoxLayout:
-        layout_buttons = QHBoxLayout()
-        self.save_button = QPushButton("Save")
-        self.cancel_button = QPushButton("Cancel")
-        self.continue_button = QPushButton("Continue")
-        layout_buttons.addWidget(self.cancel_button)
-        layout_buttons.addWidget(self.save_button)
-        layout_buttons.addWidget(self.continue_button)
-        return layout_buttons
+    def _build_buttons_layout(self) -> QGridLayout:
+        layout = QGridLayout()
 
-    # -----------------------------
-    # Load / Save
-    # -----------------------------
+        self._countdown = AutoAcceptCountdown(self)
+        self.cancel_button = QPushButton("Cancel")
+        self.save_button = QPushButton("Save")
+        self.continue_button = QPushButton("Continue")
+
+        layout.addWidget(self._countdown, 0, 2, alignment=Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(self.cancel_button, 1, 0)
+        layout.addWidget(self.save_button, 1, 1)
+        layout.addWidget(self.continue_button, 1, 2)
+
+        return layout
 
     def _load_from_config(self) -> None:
         self.base_config.load_from_model(self._config.value)
+        self.base_config.load_auto_accept_timeout(
+            self._panel_config.value.auto_accept_timeout_seconds
+        )
 
         self.rewarders_group.load_models(self._config.value.rewarders)
         self.detectors_group.load_models(self._config.value.detectors)
@@ -119,29 +123,54 @@ class MXBIPanel(QMainWindow):
     def _collect_result(self) -> None:
         self.base_config.apply_to_model(self._config.value)
 
-        # Replace instead of append so repeated Save/Continue doesn't duplicate entries.
         self._config.value.rewarders = self.rewarders_group.results()
         self._config.value.detectors = self.detectors_group.results()
 
     def _on_save(self) -> None:
         self._collect_result()
         self._config.save()
+        self._save_panel_config()
 
     def _on_continue(self) -> None:
         self._collect_result()
         self._config.save()
+        self._save_panel_config()
         self._accepted = True
         self.close()
         self.accepted.emit()
 
-    # -----------------------------
-    # Events / Menus
-    # -----------------------------
+    def _save_panel_config(self) -> None:
+        self._panel_config.value.auto_accept_timeout_seconds = (
+            self.base_config.auto_accept_timeout
+        )
+        self._panel_config.save()
+
+    def _start_auto_accept_countdown(self) -> None:
+        timeout = self._panel_config.value.auto_accept_timeout_seconds
+        if timeout > 0:
+            self._countdown.start(timeout)
+            self._countdown.timeout.connect(self._on_continue)
 
     def _bind_events(self) -> None:
         self.cancel_button.clicked.connect(self._on_cancel)
         self.save_button.clicked.connect(self._on_save)
         self.continue_button.clicked.connect(self._on_continue)
+
+        self.base_config.changed.connect(self._on_user_interaction)
+
+        self.cancel_button.clicked.connect(self._countdown.stop)
+        self.save_button.clicked.connect(self._countdown.stop)
+        self.continue_button.clicked.connect(self._countdown.stop)
+
+        self._widget_main.installEventFilter(self)
+
+    def _on_user_interaction(self, _msg: str = "") -> None:
+        self._countdown.pause()
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Type.MouseButtonPress:
+            self._countdown.pause()
+        return super().eventFilter(obj, event)
 
     def _on_cancel(self) -> None:
         self.close()

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,7 @@ name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
@@ -780,20 +780,20 @@ wheels = [
 
 [[package]]
 name = "pymotego"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "pyzmq" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/38/f9b4434dd1671f1e6f5c01afed23e739f166b6920410dcd89d97b3b83acd/pymotego-0.1.3.tar.gz", hash = "sha256:18df4cbe6efcd0d7f5e48afa0490796f7928873e8d4067865f5db5c3e4b02733", size = 3173, upload-time = "2025-10-22T22:16:47.156Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/b0/21465c9443e0ef0b2dd1af57971514948e28760759a3c99070343cecb9fb/pymotego-0.1.4.tar.gz", hash = "sha256:b755ab20f7270573c1e8efe24007e2bb587b64bf07af2239ca6953234dfccdb2", size = 3088, upload-time = "2026-02-16T23:49:07.836Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/7c/898b3f1af42f010bf08195030d44232a1ba68a1e846d780c1d617f6b90b6/pymotego-0.1.3-py3-none-any.whl", hash = "sha256:57bfc253e5344aba3000e510de3748dc91ca0bf5e230094d414ffb7455c28c6e", size = 4634, upload-time = "2025-10-22T22:16:46.058Z" },
+    { url = "https://files.pythonhosted.org/packages/07/3d/acb817ffa342ab252eb8836012585462eceaac3c9afd27449dbaaf28e504/pymotego-0.1.4-py3-none-any.whl", hash = "sha256:4bf51e5b823a103273f095f977e40a0c28e0b0ea20c243a08212dbba50e4a998", size = 4556, upload-time = "2026-02-16T23:49:08.54Z" },
 ]
 
 [[package]]
 name = "pymxbi"
-version = "0.3.2"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gpiozero" },
@@ -808,9 +808,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/a1/ad209d8768f7c2709ea7fcf9d2e4608c64d3a0f7db1db095a1c8aefb5805/pymxbi-0.3.2.tar.gz", hash = "sha256:8e2b9c10d09922eb5fa6eedf67124f6a21ad076856559bf286b5f0f13edaca4d", size = 29401, upload-time = "2026-02-17T01:44:11.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/c7/97acad4a5ff4457ee17fac9d5575a1ba4695d62a6bad000107d035e2a068/pymxbi-0.3.3.tar.gz", hash = "sha256:28760650c21e4862eccf7511b5e44494af5d014d9d5ff5b8bdb24c19031529da", size = 29391, upload-time = "2026-02-17T15:19:29.139Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/6c/b0b9f185491a79cfaa21da4f252a73b17c2af225519f5427c366509242db/pymxbi-0.3.2-py3-none-any.whl", hash = "sha256:d4db87f6505491bfd783b87df5453c4ecfcf49fdbc8e8461582c027e3b3d9283", size = 49709, upload-time = "2026-02-17T01:44:12.44Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1e/abc1dfa04e0d092293d7e8f53d8610b7f819f060cf45ce29e7821642c9b9/pymxbi-0.3.3-py3-none-any.whl", hash = "sha256:84014064b82c222054ef90cdbef03a50cb8b5079e01a2d3c9dc036361bc64aee", size = 49709, upload-time = "2026-02-17T15:19:30.391Z" },
 ]
 
 [[package]]
@@ -973,8 +973,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -1022,7 +1022,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.23.0"
+version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1030,9 +1030,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7e/e6/44e073787aa57cd71c151f44855232feb0f748428fd5242d7366e3c4ae8b/typer-0.23.0.tar.gz", hash = "sha256:d8378833e47ada5d3d093fa20c4c63427cc4e27127f6b349a6c359463087d8cc", size = 120181, upload-time = "2026-02-11T15:22:18.637Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b6/3e681d3b6bb22647509bdbfdd18055d5adc0dce5c5585359fa46ff805fdc/typer-0.24.0.tar.gz", hash = "sha256:f9373dc4eff901350694f519f783c29b6d7a110fc0dcc11b1d7e353b85ca6504", size = 118380, upload-time = "2026-02-16T22:08:48.496Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/ed/d6fca788b51d0d4640c4bc82d0e85bad4b49809bca36bf4af01b4dcb66a7/typer-0.23.0-py3-none-any.whl", hash = "sha256:79f4bc262b6c37872091072a3cb7cb6d7d79ee98c0c658b4364bdcde3c42c913", size = 56668, upload-time = "2026-02-11T15:22:21.075Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d0/4da85c2a45054bb661993c93524138ace4956cb075a7ae0c9d1deadc331b/typer-0.24.0-py3-none-any.whl", hash = "sha256:5fc435a9c8356f6160ed6e85a6301fdd6e3d8b2851da502050d1f92c5e9eddc8", size = 56441, upload-time = "2026-02-16T22:08:47.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add AutoAcceptCountdown widget that auto-clicks Continue after timeout
- Add auto_accept_timeout_seconds config option to session and panel config
- Pause countdown on user interaction, resume on panel re-open
- Countdown displays remaining time with visual feedback