### PR TITLE
fix(session): :bug: allocate session_id only when session starts

### DIFF
--- a/src/mxbiflow/bootstrap.py
+++ b/src/mxbiflow/bootstrap.py
@@ -68,7 +68,7 @@ def init_session(session_config: SessionConfig) -> Session:
         animal_dict[animal_config.name] = animal_state
 
     session = Session(
-        session_id=store.session_id,
+        session_id=0,
         experimenter=session_config.experimenter,
         reward_type=session_config.reward_type,
         send_email=False,
@@ -81,5 +81,6 @@ def init_session(session_config: SessionConfig) -> Session:
         fullscreen=session_config.fullscreen,
         animals=animal_dict,
     )
+    session.set_session_store(store)
 
     return session

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -158,9 +158,15 @@ class Session(BaseModel):
     note: str = Field(frozen=True)
 
     _current_animal: str | None = PrivateAttr(default=None)
+    _session_store: DailySessionIdStore | None = PrivateAttr(default=None)
     animals: dict[str, Animal] = Field(default_factory=dict, frozen=True)
 
+    def set_session_store(self, store: DailySessionIdStore) -> None:
+        self._session_store = store
+
     def start(self):
+        if self._session_store and self.session_id == 0:
+            self.session_id = self._session_store.session_id
         self.start_at = datetime.now(timezone.utc).timestamp()
 
     def end(self):


### PR DESCRIPTION
- Initialize session with session_id=0 instead of pre-allocating
- Inject DailySessionIdStore via set_session_store() method
- Allocate real session_id in start() only when session actually begins