### PR TITLE
refactor(session): :recycle: store session and animal timestamps as datetime

### DIFF
--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -1,9 +1,9 @@
 from pathlib import Path
+from datetime import timezone
 
 from mxbiflow import set_base_path
 from mxbiflow.bootstrap import init_gameloop
 from mxbiflow.core.path import get_email_state_path, get_mxbi_config_path
-from datetime import datetime, timezone
 
 from mxbiflow.infra.post_processing import HtmlComposer, session_overview, summarize
 from mxbiflow.models.session import EmailSendStateStore
@@ -29,7 +29,7 @@ def main() -> None:
     summary = summarize()
 
     date_str = (
-        datetime.fromtimestamp(summary.start_at, tz=timezone.utc).strftime("%Y-%m-%d")
+        summary.start_at.astimezone(timezone.utc).strftime("%Y-%m-%d")
         if summary.start_at
         else "N/A"
     )

--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -72,7 +72,7 @@ class Game:
             filename="session",
             type=DataLoggerType.JSON,
         )
-        self._session_logger.save(self._session.model_dump())
+        self._session_logger.save(self._session.model_dump(mode="json"))
 
     def play(self) -> None:
         while self._running:
@@ -128,7 +128,7 @@ class Game:
 
     def quit(self) -> None:
         self._session.end()
-        self._session_logger.save(self._session.model_dump())
+        self._session_logger.save(self._session.model_dump(mode="json"))
 
         if self._scene_manager.current is not None:
             self._scene_manager.current.quit()

--- a/src/mxbiflow/infra/post_processing.py
+++ b/src/mxbiflow/infra/post_processing.py
@@ -26,8 +26,8 @@ class AnimalSummary(BaseModel):
 
 class SessionSummary(BaseModel):
     session_id: int
-    start_at: float
-    end_at: float
+    start_at: datetime | None
+    end_at: datetime | None
     duration_seconds: float
     reward_type: str
     total_animals: int
@@ -39,11 +39,11 @@ class ReportImage(TypedDict):
     alt: str
 
 
-def _format_timestamp(ts: float) -> str:
-    if ts == 0:
+def _format_timestamp(dt: datetime | None) -> str:
+    if dt is None:
         return "N/A"
-    dt = datetime.fromtimestamp(ts)
-    return dt.strftime("%Y-%m-%d %H:%M:%S")
+
+    return dt.astimezone().strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _format_duration(seconds: float) -> str:
@@ -62,7 +62,7 @@ def _calc_animal_duration(sessions: list) -> float:
     total = 0.0
     for s in sessions:
         if s.start_at and s.end_at:
-            total += s.end_at - s.start_at
+            total += (s.end_at - s.start_at).total_seconds()
     return total
 
 
@@ -103,7 +103,9 @@ def summarize() -> SessionSummary:
             )
         )
 
-    duration = session.end_at - session.start_at if session.end_at > 0 else 0
+    duration = 0.0
+    if session.start_at and session.end_at:
+        duration = (session.end_at - session.start_at).total_seconds()
 
     return SessionSummary(
         session_id=session.session_id,
@@ -123,7 +125,11 @@ def session_overview() -> str:
 
     context = {
         "session_id": summary.session_id,
-        "session_date": datetime.fromtimestamp(summary.start_at).strftime("%Y-%m-%d"),
+        "session_date": (
+            summary.start_at.astimezone().strftime("%Y-%m-%d")
+            if summary.start_at
+            else "N/A"
+        ),
         "start_time": _format_timestamp(summary.start_at),
         "end_time": _format_timestamp(summary.end_at),
         "duration": _format_duration(summary.duration_seconds),

--- a/src/mxbiflow/models/animal.py
+++ b/src/mxbiflow/models/animal.py
@@ -1,7 +1,7 @@
-from time import time
+from datetime import datetime, timezone
 from typing import TypeVar
 
-from pydantic import BaseModel, Field, PrivateAttr
+from pydantic import BaseModel, Field, PrivateAttr, field_serializer
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -55,9 +55,16 @@ class StageState(BaseModel):
 
 class AnimalSessionState(BaseModel):
     session_id: int = Field(ge=0)
-    start_at: float = Field(default_factory=lambda: time())
-    end_at: float | None = None
+    start_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    end_at: datetime | None = None
     trial_id: int = Field(default=0, ge=0)
+
+    @field_serializer("start_at", "end_at", when_used="json")
+    def _serialize_timestamp(self, value: datetime | None) -> str | None:
+        if value is None:
+            return None
+
+        return value.astimezone().isoformat(timespec="microseconds")
 
 
 class Animal(BaseModel):
@@ -99,7 +106,7 @@ class Animal(BaseModel):
         if self._current_animal_session is None:
             raise ValueError("Animal session is not started")
 
-        self._current_animal_session.end_at = time()
+        self._current_animal_session.end_at = datetime.now(timezone.utc)
         self._current_animal_session = None
 
     @property

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
-from pydantic import BaseModel, Field, PrivateAttr, ValidationError
+from pydantic import BaseModel, Field, PrivateAttr, ValidationError, field_serializer
 
 from .animal import Animal, AnimalConfig
 from .reward import RewardEnum
@@ -153,8 +153,8 @@ class Session(BaseModel):
     fullscreen: bool = Field(default=False, frozen=True)
 
     session_id: int = Field(default=0, ge=0)
-    start_at: float = Field(default=0, ge=0)
-    end_at: float = Field(default=0, ge=0)
+    start_at: datetime | None = Field(default=None)
+    end_at: datetime | None = Field(default=None)
     note: str = Field(frozen=True)
 
     _current_animal: str | None = PrivateAttr(default=None)
@@ -167,10 +167,17 @@ class Session(BaseModel):
     def start(self):
         if self._session_store and self.session_id == 0:
             self.session_id = self._session_store.session_id
-        self.start_at = datetime.now(timezone.utc).timestamp()
+        self.start_at = datetime.now(timezone.utc)
 
     def end(self):
-        self.end_at = datetime.now(timezone.utc).timestamp()
+        self.end_at = datetime.now(timezone.utc)
+
+    @field_serializer("start_at", "end_at", when_used="json")
+    def _serialize_timestamp(self, value: datetime | None) -> str | None:
+        if value is None:
+            return None
+
+        return value.astimezone().isoformat(timespec="microseconds")
 
     @property
     def current_animal(self) -> Animal | None:


### PR DESCRIPTION
- switch session and animal start/end fields from float timestamps to timezone-aware datetime values
- keep JSON output human-readable with local-time ISO 8601 serialization including microseconds
- update summary and report formatting logic to compute durations from datetime values