### PR TITLE
fix(session): :bug: fix daily rollover for session data directories

### DIFF
--- a/src/mxbiflow/infra/data_logger.py
+++ b/src/mxbiflow/infra/data_logger.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 from ..utils.logger import logger
 
-now = datetime.now()
-
 
 class DataLoggerType(StrEnum):
     JSONL = "jsonl"
@@ -39,7 +37,7 @@ class DataLogger:
         return self._data_path
 
     def _ensure_data_dir(self) -> Path:
-        date_path = Path(f"{now.year}{now.month:02d}{now.day:02d}")
+        date_path = Path(datetime.now().strftime("%Y%m%d"))
         session_path = Path(f"{self._session_id}")
 
         if self._monkey:

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -30,9 +30,7 @@ class SessionConfig(BaseModel):
 
 
 class DailySessionCounter(BaseModel):
-    day: str = Field(
-        default_factory=lambda: datetime.now(timezone.utc).date().isoformat()
-    )
+    day: str = Field(default_factory=lambda: datetime.now().date().isoformat())
     last_session_id: int = Field(default=0, ge=0)
 
 
@@ -45,8 +43,8 @@ class EmailSendState(BaseModel):
 class DailySessionIdStore:
     path: Path
 
-    def _today_utc(self):
-        return datetime.now(timezone.utc).date().isoformat()
+    def _today_local(self) -> str:
+        return datetime.now().date().isoformat()
 
     def _load(self) -> DailySessionCounter:
         if not self.path.exists():
@@ -82,7 +80,7 @@ class DailySessionIdStore:
 
     @property
     def session_id(self) -> int:
-        today = self._today_utc()
+        today = self._today_local()
         data = self._load()
 
         if data.day != today:


### PR DESCRIPTION
- compute data directory date at logger creation time instead of module import time
- align daily session counter rollover with local date to match directory naming semantics