### PR TITLE
feat(models): ✨ add initial/final stage serialization to Animal

### DIFF
--- a/src/mxbiflow/models/animal.py
+++ b/src/mxbiflow/models/animal.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import TypeVar
 
-from pydantic import BaseModel, Field, PrivateAttr, field_serializer
+from pydantic import BaseModel, Field, PrivateAttr, computed_field, field_serializer
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -75,6 +75,7 @@ class Animal(BaseModel):
 
     _current_stage: str = PrivateAttr(default="idle")
     _stages: dict[str, StageState] = PrivateAttr(default_factory=dict)
+    _initial_stage: StageState | None = PrivateAttr(default=None)
     _current_animal_session: AnimalSessionState | None = PrivateAttr(default=None)
     _sessions: list[AnimalSessionState] = PrivateAttr(default_factory=list)
 
@@ -125,9 +126,13 @@ class Animal(BaseModel):
 
         self._current_stage = stage.stage_name
         if stage.stage_name in self._stages:
+            if self._initial_stage is None:
+                self._initial_stage = self._stages[stage.stage_name].model_copy(deep=True)
             return
 
         self._stages[stage.stage_name] = stage
+        if self._initial_stage is None:
+            self._initial_stage = stage.model_copy(deep=True)
 
     def clear_current_stage(self) -> None:
         self._current_stage = "idle"
@@ -139,6 +144,19 @@ class Animal(BaseModel):
     def level_down(self) -> int:
         self.current_stage.level_down()
         return self.current_stage.level
+
+    @computed_field
+    @property
+    def initial_stage(self) -> StageState | None:
+        return self._initial_stage
+
+    @computed_field
+    @property
+    def final_stage(self) -> StageState | None:
+        try:
+            return self.current_stage
+        except ValueError:
+            return None
 
     @property
     def base_info(self) -> AnimalBaseInfo:

--- a/uv.lock
+++ b/uv.lock
@@ -557,7 +557,7 @@ wheels = [
 
 [[package]]
 name = "mxbiflow"
-version = "0.3.13"
+version = "0.3.15"
 source = { editable = "." }
 dependencies = [
     { name = "gpiozero" },
@@ -570,7 +570,6 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pillow" },
-    { name = "pyaudio" },
     { name = "pydantic" },
     { name = "pygame-ce" },
     { name = "pymotego" },
@@ -595,7 +594,6 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.3.3" },
     { name = "pandas", specifier = ">=2.3.2" },
     { name = "pillow", specifier = ">=11.3.0" },
-    { name = "pyaudio", specifier = ">=0.2.14" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pygame-ce", specifier = ">=2.5.6" },
     { name = "pymotego", specifier = ">=0.1.3" },
@@ -719,12 +717,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
-
-[[package]]
-name = "pyaudio"
-version = "0.2.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/26/1d/8878c7752febb0f6716a7e1a52cb92ac98871c5aa522cba181878091607c/PyAudio-0.2.14.tar.gz", hash = "sha256:78dfff3879b4994d1f4fc6485646a57755c6ee3c19647a491f790a0895bd2f87", size = 47066, upload-time = "2023-11-07T07:11:48.806Z" }
 
 [[package]]
 name = "pycparser"


### PR DESCRIPTION
## Summary

- Add `initial_stage` and `final_stage` as Pydantic `computed_field` on `Animal`
- Record a deep copy of the initial `StageState` on first `set_current_stage()`, so startup stage/level info is preserved even after `level_up()` / `level_down()`
- `final_stage` reflects the current stage state at serialization time
- Both fields now appear in `Session.model_dump(mode="json")` → persisted to `session.json`

## Motivation

Previously the session JSON only contained `rfid_id`, `name`, and `trial_id` per animal — stage name, levels, and trial counts were hidden in `PrivateAttr` and not serialized. This change makes the initial and final training stage visible in the final saved data, which is needed for experiment analysis and reporting.

## Changes

| File | Change |
|------|--------|
| `src/mxbiflow/models/animal.py` | +20/-10, add `_initial_stage` private attr + two computed fields |
| `uv.lock` | +1/-9, cleanup from validation run |