### PR TITLE
refactor(session): :recycle: separate config and runtime state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pillow>=11.3.0",
     "pydantic>=2.11.7",
     "pygame-ce>=2.5.6",
-    "pymotego>=0.1.3",
+    "pymotego>=0.1.6",
     "pymxbi>=0.3.7",
     "pyserial>=3.5",
     "pyside6>=6.10.1",
@@ -31,6 +31,13 @@ dependencies = [
 
 [tool.uv.sources]
 pymotego = { path = "/Users/ccccr/repo/projects/cogmote/cogmote/pymoteGO", editable = true }
+
+[tool.pyright]
+include = ["src/mxbiflow", "tests"]
+exclude = ["src/mxbiflow/tasks"]
+extraPaths = ["src"]
+typeCheckingMode = "basic"
+reportPrivateUsage = "error"
 
 [project.scripts]
 mxbi = "mxbi:main"

--- a/src/mxbiflow/bootstrap.py
+++ b/src/mxbiflow/bootstrap.py
@@ -11,7 +11,7 @@ from .core.path import (
 from .gameloop.detector_bridge import DetectorBridge
 from .gameloop.game import Game
 from .models.animal import Animal, StageState
-from .models.session import DailySessionIdStore, Session, SessionConfig
+from .models.session import DailySessionIdStore, Session, SessionConfig, SessionState
 from .scene import SceneManager
 
 
@@ -69,26 +69,15 @@ def init_session(session_config: SessionConfig) -> Session:
             level=animal_config.level,
         )
         animal_state = Animal(
-            rfid_id=animal_config.rfid_id,
-            name=animal_config.name,
+            config=animal_config,
+            current_stage_name=train_state.stage_name,
+            stages={train_state.stage_name: train_state},
         )
-        animal_state.set_current_stage(train_state)
         animal_dict[animal_config.name] = animal_state
 
     session = Session(
-        session_id=0,
-        experimenter=session_config.experimenter,
-        reward_type=session_config.reward_type,
-        send_email=False,
-        sync_data=False,
-        note=session_config.note,
-        default_scene=session_config.default_scene,
-        unknown_animal_fallback=session_config.unknown_animal_fallback,
-        unknown_animal_fallback_animal=session_config.unknown_animal_fallback_animal,
-        fault_fallback=session_config.fault_fallback,
-        hide_cursor=session_config.hide_cursor,
-        fullscreen=session_config.fullscreen,
-        animals=animal_dict,
+        config=session_config,
+        state=SessionState(animals=animal_dict),
     )
     session.set_session_store(store)
 

--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -6,7 +6,6 @@ from pymxbi import MXBI
 
 from ..core.context import MXBIFlow, set_mxbiflow
 from ..core.path import get_data_dir_path
-from ..infra.data_logger import DataLogger, DataLoggerType
 from ..models.session import Session
 from ..scene import SceneManager
 from ..utils.logger import logger
@@ -71,13 +70,11 @@ class Game:
         self._mxbi.begin()
         self._scene_manager.init()
 
+        if self._scene_manager.current is not None:
+            self._session.set_current_scene(
+                type(self._scene_manager.current).__name__.lower()
+            )
         self._session.start(get_data_dir_path())
-        self._session_logger = DataLogger(
-            session=self._session,
-            filename="session",
-            type=DataLoggerType.JSON,
-        )
-        self._session_logger.save(self._session.model_dump(mode="json"))
 
     def play(self) -> None:
         while self._running:
@@ -99,7 +96,13 @@ class Game:
             self._screen.fill((0, 0, 0))
 
             self._scene_manager.draw(self._screen)
-            self._scene_manager.apply_pending()
+            if (
+                self._scene_manager.apply_pending()
+                and self._scene_manager.current is not None
+            ):
+                self._session.set_current_scene(
+                    type(self._scene_manager.current).__name__.lower()
+                )
 
             pygame.display.flip()
 
@@ -126,7 +129,10 @@ class Game:
                 pass
 
     def _capture_screen(self) -> None:
-        screenshot_dir = self._session_logger.path.parent / "screenshots"
+        data_path = self._session.absolute_data_path
+        if data_path is None:
+            raise RuntimeError("Session data path is not available")
+        screenshot_dir = data_path / "screenshots"
         screenshot_dir.mkdir(parents=True, exist_ok=True)
 
         timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")
@@ -136,11 +142,9 @@ class Game:
         logger.info("screen captured: {}", screenshot_path)
 
     def quit(self) -> None:
-        self._session.end()
-        self._session_logger.save(self._session.model_dump(mode="json"))
-
         if self._scene_manager.current is not None:
             self._scene_manager.current.quit()
+        self._session.end()
         self._mxbi.quit()
         if pygame.display.get_init():
             pygame.display.quit()

--- a/src/mxbiflow/gameloop/scheduler.py
+++ b/src/mxbiflow/gameloop/scheduler.py
@@ -38,7 +38,7 @@ class Scheduler:
         if self._session.current_animal is None:
             return
 
-        self._session.current_animal.set_current_stage(stage)
+        self._session.set_current_stage(stage)
         self._need_refresh = True
 
     def _handle_fault_event(self) -> None:

--- a/src/mxbiflow/infra/post_processing.py
+++ b/src/mxbiflow/infra/post_processing.py
@@ -99,8 +99,8 @@ def summarize() -> SessionSummary:
                 name=name,
                 rfid_id=animal.rfid_id,
                 total_trials=animal.trial_id,
-                animal_sessions=len(animal.sessions),
-                total_duration_seconds=_calc_animal_duration(animal.sessions),
+                animal_sessions=len(animal.animal_sessions),
+                total_duration_seconds=_calc_animal_duration(animal.animal_sessions),
                 stages=stages,
             )
         )

--- a/src/mxbiflow/models/animal.py
+++ b/src/mxbiflow/models/animal.py
@@ -1,14 +1,45 @@
-from collections.abc import Mapping, Sequence
+from copy import deepcopy
 from datetime import UTC, datetime
 
-from pydantic import BaseModel, Field, PrivateAttr, computed_field, field_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializeAsAny,
+    computed_field,
+    field_serializer,
+)
+
+type ContextMap = dict[str, SerializeAsAny[BaseModel]]
+
+
+def validate_context_key(key: str) -> None:
+    if not key.strip():
+        raise ValueError("context key must not be empty")
+
+
+class ContextState(BaseModel):
+    contexts: ContextMap = Field(default_factory=dict)
+
+    def get_context[T: BaseModel](self, key: str, context_type: type[T]) -> T | None:
+        validate_context_key(key)
+        context = self.contexts.get(key)
+        if context is None:
+            return None
+        if not isinstance(context, context_type):
+            raise TypeError(
+                f"Expected {context_type.__name__}, got {type(context).__name__}"
+            )
+        return context
 
 
 class AnimalConfig(BaseModel):
-    rfid_id: str = Field(default="", frozen=True)
-    name: str = Field(default="mock", frozen=True)
-    stage: str = Field(default="idle", frozen=True)
-    level: int = Field(default=0, ge=0, frozen=True)
+    model_config = ConfigDict(frozen=True)
+
+    rfid_id: str = ""
+    name: str = "mock"
+    stage: str = "idle"
+    level: int = Field(default=0, ge=0)
 
 
 class AnimalBaseInfo(BaseModel):
@@ -20,7 +51,7 @@ class AnimalBaseInfo(BaseModel):
     animal_session_trial_id: int
 
 
-class StageState(BaseModel):
+class StageState(ContextState):
     stage_name: str
     stage_trial_id: int = Field(default=0, ge=0)
 
@@ -28,27 +59,26 @@ class StageState(BaseModel):
     level: int = Field(default=0, ge=0)
     level_trial_id: int = Field(default=0, ge=0)
 
-    _context: BaseModel | None = PrivateAttr(default=None)
 
-    def get_context[T: BaseModel](self, context_type: type[T]) -> T | None:
-        if self._context is None:
-            return None
-        if not isinstance(self._context, context_type):
-            raise TypeError(
-                f"Expected {context_type.__name__}, got {type(self._context).__name__}"
-            )
-        return self._context
+class StageSnapshot(ContextState):
+    model_config = ConfigDict(frozen=True)
 
-    def set_context(self, context: BaseModel) -> None:
-        self._context = context
+    stage_name: str
+    stage_trial_id: int = Field(ge=0)
+    initial_level: int = Field(ge=0)
+    level: int = Field(ge=0)
+    level_trial_id: int = Field(ge=0)
 
-    def level_up(self):
-        self.level_trial_id = 0
-        self.level += 1
-
-    def level_down(self):
-        self.level_trial_id = 0
-        self.level -= 1
+    @classmethod
+    def from_state(cls, state: StageState) -> StageSnapshot:
+        return cls(
+            contexts=deepcopy(state.contexts),
+            stage_name=state.stage_name,
+            stage_trial_id=state.stage_trial_id,
+            initial_level=state.initial_level,
+            level=state.level,
+            level_trial_id=state.level_trial_id,
+        )
 
 
 class AnimalSessionState(BaseModel):
@@ -61,118 +91,41 @@ class AnimalSessionState(BaseModel):
     def _serialize_timestamp(self, value: datetime | None) -> str | None:
         if value is None:
             return None
-
         return value.astimezone().isoformat(timespec="microseconds")
 
 
-class Animal(BaseModel):
-    rfid_id: str = Field(frozen=True)
-    name: str = Field(frozen=True)
+class Animal(ContextState):
+    config: AnimalConfig = Field(frozen=True, exclude=True)
 
     trial_id: int = Field(default=0, ge=0)
+    current_stage_name: str = "idle"
+    stages: dict[str, StageState] = Field(default_factory=dict)
+    initial_stage: StageSnapshot | None = None
+    final_stage: StageSnapshot | None = None
+    current_animal_session: AnimalSessionState | None = None
+    animal_sessions: list[AnimalSessionState] = Field(default_factory=list)
 
-    _current_stage: str = PrivateAttr(default="idle")
-    _stages: dict[str, StageState] = PrivateAttr(
-        default_factory=dict[str, StageState]
-    )
-    _initial_stage: StageState | None = PrivateAttr(default=None)
-    _current_animal_session: AnimalSessionState | None = PrivateAttr(default=None)
-    _sessions: list[AnimalSessionState] = PrivateAttr(
-        default_factory=list[AnimalSessionState]
-    )
-
-    def add_trial(self) -> None:
-        self.trial_id += 1
-        self.current_stage.stage_trial_id += 1
-        self.current_stage.level_trial_id += 1
-        assert self.current_animal_session is not None
-        self.current_animal_session.trial_id += 1
-
+    @computed_field
     @property
-    def current_animal_session(self) -> AnimalSessionState | None:
-        return self._current_animal_session
+    def rfid_id(self) -> str:
+        return self.config.rfid_id
 
+    @computed_field
     @property
-    def stages(self) -> Mapping[str, StageState]:
-        return self._stages
-
-    @property
-    def sessions(self) -> Sequence[AnimalSessionState]:
-        return self._sessions
-
-    def start_animal_session(self):
-        session_id = 1
-
-        if self._current_animal_session is not None:
-            raise ValueError("Animal session is already started")
-
-        if self._sessions:
-            session_id = len(self._sessions) + 1
-
-        session = AnimalSessionState(session_id=session_id)
-        self._current_animal_session = session
-        self._sessions.append(session)
-
-    def end_animal_session(self):
-        if self._current_animal_session is None:
-            raise ValueError("Animal session is not started")
-
-        self._current_animal_session.end_at = datetime.now(UTC)
-        self._current_animal_session = None
+    def name(self) -> str:
+        return self.config.name
 
     @property
     def current_stage(self) -> StageState:
-        key = self._current_stage
-
-        state = self._stages.get(key)
+        state = self.stages.get(self.current_stage_name)
         if state is None:
-            raise ValueError(f"Unknown stage: {key}")
-
+            raise ValueError(f"Unknown stage: {self.current_stage_name}")
         return state
-
-    def set_current_stage(self, stage: StageState | str) -> None:
-        if isinstance(stage, str):
-            stage = StageState(stage_name=stage)
-
-        self._current_stage = stage.stage_name
-        if stage.stage_name in self._stages:
-            if self._initial_stage is None:
-                self._initial_stage = self._stages[stage.stage_name].model_copy(
-                    deep=True
-                )
-            return
-
-        self._stages[stage.stage_name] = stage
-        if self._initial_stage is None:
-            self._initial_stage = stage.model_copy(deep=True)
-
-    def clear_current_stage(self) -> None:
-        self._current_stage = "idle"
-
-    def level_up(self) -> int:
-        self.current_stage.level_up()
-        return self.current_stage.level
-
-    def level_down(self) -> int:
-        self.current_stage.level_down()
-        return self.current_stage.level
-
-    @computed_field
-    @property
-    def initial_stage(self) -> StageState | None:
-        return self._initial_stage
-
-    @computed_field
-    @property
-    def final_stage(self) -> StageState | None:
-        try:
-            return self.current_stage
-        except ValueError:
-            return None
 
     @property
     def base_info(self) -> AnimalBaseInfo:
-        if self.current_animal_session is None:
+        current_session = self.current_animal_session
+        if current_session is None:
             raise ValueError("Animal session is not started")
 
         return AnimalBaseInfo(
@@ -180,6 +133,6 @@ class Animal(BaseModel):
             trial_id=self.trial_id,
             level=self.current_stage.level,
             level_trial_id=self.current_stage.level_trial_id,
-            animal_session_id=self.current_animal_session.session_id,
-            animal_session_trial_id=self.current_animal_session.trial_id,
+            animal_session_id=current_session.session_id,
+            animal_session_trial_id=current_session.trial_id,
         )

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -1,33 +1,68 @@
+import json
 import os
 import tempfile
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pydantic import BaseModel, Field, PrivateAttr, ValidationError, field_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    computed_field,
+    field_serializer,
+)
 
-from .animal import Animal, AnimalConfig
+from .animal import (
+    Animal,
+    AnimalConfig,
+    AnimalSessionState,
+    ContextState,
+    StageSnapshot,
+    StageState,
+    validate_context_key,
+)
 from .reward import RewardEnum
 
 
 class SessionConfig(BaseModel):
-    experimenter: str = Field(default="auto", frozen=True)
-    reward_type: RewardEnum = Field(default=RewardEnum.AGUM_ONE_FIFTH, frozen=True)
-    send_email: bool = Field(default=False, frozen=True)
-    sync_data: bool = Field(default=False, frozen=True)
+    model_config = ConfigDict(frozen=True)
+
+    experimenter: str = "auto"
+    reward_type: RewardEnum = RewardEnum.AGUM_ONE_FIFTH
+    send_email: bool = False
+    sync_data: bool = False
     note: str = Field(default="", max_length=1000)
 
-    default_scene: str = Field(default="")
-    unknown_animal_fallback: str = Field(default="")
-    unknown_animal_fallback_animal: str = Field(default="")
-    fault_fallback: str = Field(default="")
+    default_scene: str = ""
+    unknown_animal_fallback: str = ""
+    unknown_animal_fallback_animal: str = ""
+    fault_fallback: str = ""
 
-    hide_cursor: bool = Field(default=False)
-    fullscreen: bool = Field(default=False)
-
+    hide_cursor: bool = False
+    fullscreen: bool = False
     auto_accept_timeout_seconds: int = Field(default=60, ge=0)
 
-    animals: list[AnimalConfig] = Field(default_factory=list[AnimalConfig])
+    animals: tuple[AnimalConfig, ...] = ()
+
+
+class SessionState(ContextState):
+    session_id: int = Field(default=0, ge=0)
+    start_at: datetime | None = None
+    end_at: datetime | None = None
+    data_path: Path | None = None
+    current_scene: str | None = None
+    current_animal_name: str | None = None
+    animals: dict[str, Animal] = Field(default_factory=dict)
+
+    @field_serializer("start_at", "end_at", when_used="json")
+    def _serialize_timestamp(self, value: datetime | None) -> str | None:
+        if value is None:
+            return None
+        return value.astimezone().isoformat(timespec="microseconds")
 
 
 class DailySessionCounter(BaseModel):
@@ -37,7 +72,28 @@ class DailySessionCounter(BaseModel):
 
 class EmailSendState(BaseModel):
     sent_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    message_id: str = Field(default="")
+    message_id: str = ""
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(path.parent),
+        prefix=path.name,
+        suffix=".tmp",
+    )
+
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            file.write(text)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(tmp, path)
+    finally:
+        try:
+            os.remove(tmp)
+        except FileNotFoundError:
+            pass
 
 
 @dataclass
@@ -51,33 +107,10 @@ class DailySessionIdStore:
         if not self.path.exists():
             return DailySessionCounter()
 
-        text = self.path.read_text()
-
         try:
-            return DailySessionCounter.model_validate_json(text)
+            return DailySessionCounter.model_validate_json(self.path.read_text())
         except ValueError, ValidationError:
             return DailySessionCounter()
-
-    def _atomic_write(self, data: DailySessionCounter) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(self.path.parent),
-            prefix=self.path.name,
-            suffix=".tmp",
-        )
-
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(data.model_dump_json())
-                f.flush()
-                os.fsync(f.fileno())
-
-            os.replace(tmp, self.path)
-        finally:
-            try:
-                os.remove(tmp)
-            except FileNotFoundError:
-                pass
 
     @property
     def session_id(self) -> int:
@@ -89,8 +122,7 @@ class DailySessionIdStore:
             data.last_session_id = 0
 
         data.last_session_id += 1
-        self._atomic_write(data)
-
+        _atomic_write(self.path, data.model_dump_json())
         return data.last_session_id
 
 
@@ -102,134 +134,358 @@ class EmailSendStateStore:
         if not self.path.exists():
             return EmailSendState()
 
-        text = self.path.read_text()
-
         try:
-            return EmailSendState.model_validate_json(text)
+            return EmailSendState.model_validate_json(self.path.read_text())
         except ValueError, ValidationError:
             return EmailSendState()
-
-    def _atomic_write(self, data: EmailSendState) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        fd, tmp = tempfile.mkstemp(
-            dir=str(self.path.parent),
-            prefix=self.path.name,
-            suffix=".tmp",
-        )
-
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(data.model_dump_json())
-                f.flush()
-                os.fsync(f.fileno())
-
-            os.replace(tmp, self.path)
-        finally:
-            try:
-                os.remove(tmp)
-            except FileNotFoundError:
-                pass
 
     def load(self) -> EmailSendState:
         return self._load()
 
     def save(self, message_id: str) -> None:
-        data = EmailSendState(message_id=message_id)
-        self._atomic_write(data)
+        _atomic_write(
+            self.path,
+            EmailSendState(message_id=message_id).model_dump_json(),
+        )
+
+
+@dataclass
+class SessionSnapshotStore:
+    path: Path
+
+    def save(self, snapshot: Mapping[str, object]) -> None:
+        text = json.dumps(snapshot, ensure_ascii=False, indent=2)
+        _atomic_write(self.path, text)
 
 
 class Session(BaseModel):
-    experimenter: str = Field(default="auto", frozen=True)
-    reward_type: RewardEnum = Field(default=RewardEnum.AGUM_ONE_FIFTH, frozen=True)
-    send_email: bool = Field(default=False, frozen=True)
-    sync_data: bool = Field(default=False, frozen=True)
+    config: SessionConfig
+    state: SessionState
 
-    default_scene: str = Field(default="", frozen=True)
-    unknown_animal_fallback: str = Field(default="", frozen=True)
-    unknown_animal_fallback_animal: str = Field(default="", frozen=True)
-    fault_fallback: str = Field(default="", frozen=True)
-
-    hide_cursor: bool = Field(default=False, frozen=True)
-    fullscreen: bool = Field(default=False, frozen=True)
-
-    session_id: int = Field(default=0, ge=0)
-    start_at: datetime | None = Field(default=None)
-    end_at: datetime | None = Field(default=None)
-    data_path: Path | None = Field(default=None)
-    note: str = Field(frozen=True)
-
-    _current_animal: str | None = PrivateAttr(default=None)
     _session_store: DailySessionIdStore | None = PrivateAttr(default=None)
+    _snapshot_store: SessionSnapshotStore | None = PrivateAttr(default=None)
     _data_root: Path | None = PrivateAttr(default=None)
-    animals: dict[str, Animal] = Field(default_factory=dict[str, Animal], frozen=True)
+
+    @computed_field
+    @property
+    def experimenter(self) -> str:
+        return self.config.experimenter
+
+    @computed_field
+    @property
+    def reward_type(self) -> RewardEnum:
+        return self.config.reward_type
+
+    @computed_field
+    @property
+    def send_email(self) -> bool:
+        return self.config.send_email
+
+    @computed_field
+    @property
+    def sync_data(self) -> bool:
+        return self.config.sync_data
+
+    @computed_field
+    @property
+    def note(self) -> str:
+        return self.config.note
+
+    @computed_field
+    @property
+    def default_scene(self) -> str:
+        return self.config.default_scene
+
+    @computed_field
+    @property
+    def unknown_animal_fallback(self) -> str:
+        return self.config.unknown_animal_fallback
+
+    @computed_field
+    @property
+    def unknown_animal_fallback_animal(self) -> str:
+        return self.config.unknown_animal_fallback_animal
+
+    @computed_field
+    @property
+    def fault_fallback(self) -> str:
+        return self.config.fault_fallback
+
+    @computed_field
+    @property
+    def hide_cursor(self) -> bool:
+        return self.config.hide_cursor
+
+    @computed_field
+    @property
+    def fullscreen(self) -> bool:
+        return self.config.fullscreen
+
+    @computed_field
+    @property
+    def auto_accept_timeout_seconds(self) -> int:
+        return self.config.auto_accept_timeout_seconds
+
+    @computed_field
+    @property
+    def session_id(self) -> int:
+        return self.state.session_id
+
+    @computed_field
+    @property
+    def start_at(self) -> datetime | None:
+        return self.state.start_at
+
+    @computed_field
+    @property
+    def end_at(self) -> datetime | None:
+        return self.state.end_at
+
+    @computed_field
+    @property
+    def data_path(self) -> Path | None:
+        return self.state.data_path
+
+    @computed_field
+    @property
+    def current_scene(self) -> str | None:
+        return self.state.current_scene
+
+    @computed_field
+    @property
+    def animals(self) -> Mapping[str, Animal]:
+        return self.state.animals
+
+    @computed_field
+    @property
+    def current_animal(self) -> Animal | None:
+        key = self.state.current_animal_name
+        if key is None:
+            return None
+        return self.state.animals[key]
+
+    def require_current_animal(self) -> Animal:
+        animal = self.current_animal
+        if animal is None:
+            raise RuntimeError(
+                "Animal is not set. Please call set_current_animal() first"
+            )
+        return animal
+
+    @property
+    def absolute_data_path(self) -> Path | None:
+        if self.state.data_path is None or self._data_root is None:
+            return None
+        return self._data_root / self.state.data_path
 
     def set_session_store(self, store: DailySessionIdStore) -> None:
         self._session_store = store
 
+    def set_snapshot_store(self, store: SessionSnapshotStore) -> None:
+        self._snapshot_store = store
+
+    def snapshot(self) -> dict[str, object]:
+        computed_fields = set(type(self).model_computed_fields)
+        return self.model_dump(mode="json", exclude=computed_fields)
+
+    def checkpoint(self) -> None:
+        if self._snapshot_store is not None:
+            self._snapshot_store.save(self.snapshot())
+
     def start(self, data_root: Path) -> None:
-        if self._session_store and self.session_id == 0:
-            self.session_id = self._session_store.session_id
-        self.start_at = datetime.now(UTC)
+        if self.state.start_at is not None:
+            raise RuntimeError("Session is already started")
+
+        if self._session_store is not None and self.state.session_id == 0:
+            self.state.session_id = self._session_store.session_id
+
+        self.state.start_at = datetime.now(UTC)
         self._data_root = data_root.resolve()
-        self.data_path = Path(self.start_at.strftime("%Y%m%d")) / str(
-            self.session_id
+        self.state.data_path = Path(self.state.start_at.strftime("%Y%m%d")) / str(
+            self.state.session_id
         )
 
-    def end(self) -> None:
-        self.end_at = datetime.now(UTC)
-
-    @property
-    def absolute_data_path(self) -> Path | None:
-        if self.data_path is None or self._data_root is None:
-            return None
-        return self._data_root / self.data_path
-
-    @field_serializer("start_at", "end_at", when_used="json")
-    def _serialize_timestamp(self, value: datetime | None) -> str | None:
-        if value is None:
-            return None
-
-        return value.astimezone().isoformat(timespec="microseconds")
-
-    @property
-    def current_animal(self) -> Animal | None:
-        key = self._current_animal
-        if key is None:
-            return None
-
-        return self.animals[key]
-
-    @property
-    def require_current_animal(self) -> Animal:
-        key = self._current_animal
-        if key is None:
-            raise RuntimeError(
-                f"Animal: {key} is not set. Please call set_current_animal() first"
+        absolute_data_path = self.absolute_data_path
+        assert absolute_data_path is not None
+        if self._snapshot_store is None:
+            self._snapshot_store = SessionSnapshotStore(
+                absolute_data_path / "session.json"
             )
+        self.checkpoint()
 
-        return self.animals[key]
-
-    def clear_current_animal(self):
-        a = self.current_animal
-        if a is None:
+    def end(self) -> None:
+        if self.state.start_at is None:
+            raise RuntimeError("Session is not started")
+        if self.state.end_at is not None:
             return
 
-        a.end_animal_session()
-        self._current_animal = None
+        animal = self.current_animal
+        if animal is not None:
+            self._end_animal_session(animal)
+            self.state.current_animal_name = None
+        self.state.end_at = datetime.now(UTC)
+        self.checkpoint()
 
-    def set_current_animal(self, animal: str):
-        self.clear_current_animal()
+    def set_current_scene(self, scene: str | None) -> None:
+        if self.state.current_scene == scene:
+            return
+        self.state.current_scene = scene
+        self.checkpoint()
 
+    def clear_current_animal(self) -> None:
+        animal = self.current_animal
+        if animal is None:
+            return
+
+        self._end_animal_session(animal)
+        self.state.current_animal_name = None
+        self.checkpoint()
+
+    def set_current_animal(self, animal: str) -> None:
         try:
-            a = self.animals[animal]
-        except KeyError:
-            raise ValueError(f"animal {animal} not found")
+            next_animal = self.state.animals[animal]
+        except KeyError as error:
+            raise ValueError(f"animal {animal} not found") from error
 
-        self._current_animal = animal
-        a.start_animal_session()
+        current = self.current_animal
+        if (
+            next_animal is not current
+            and next_animal.current_animal_session is not None
+        ):
+            raise ValueError(f"animal {animal} session is already started")
+        if current is not None:
+            self._end_animal_session(current)
+
+        self.state.current_animal_name = animal
+        self._start_animal_session(next_animal)
+        self.checkpoint()
+
+    def set_current_stage(self, stage: StageState | str) -> None:
+        animal = self.require_current_animal()
+        if isinstance(stage, str):
+            stage = StageState(stage_name=stage)
+
+        animal.current_stage_name = stage.stage_name
+        animal.stages.setdefault(stage.stage_name, stage)
+        self.checkpoint()
+
+    def add_trial(self) -> None:
+        animal = self.require_current_animal()
+        animal_session = animal.current_animal_session
+        if animal_session is None:
+            raise RuntimeError("Animal session is not started")
+        stage = animal.current_stage
+
+        animal.trial_id += 1
+        stage.stage_trial_id += 1
+        stage.level_trial_id += 1
+        animal_session.trial_id += 1
+        self.checkpoint()
+
+    def level_up(
+        self,
+        *,
+        animal: str | None = None,
+        stage: str | None = None,
+    ) -> int:
+        stage_state = self._resolve_stage(animal=animal, stage=stage)
+        stage_state.level_trial_id = 0
+        stage_state.level += 1
+        self.checkpoint()
+        return stage_state.level
+
+    def level_down(
+        self,
+        *,
+        animal: str | None = None,
+        stage: str | None = None,
+    ) -> int:
+        stage_state = self._resolve_stage(animal=animal, stage=stage)
+        if stage_state.level == 0:
+            raise ValueError("level cannot be less than 0")
+
+        stage_state.level_trial_id = 0
+        stage_state.level -= 1
+        self.checkpoint()
+        return stage_state.level
+
+    def get_context[T: BaseModel](self, key: str, context_type: type[T]) -> T | None:
+        return self.state.get_context(key, context_type)
+
+    def set_context(self, key: str, context: BaseModel) -> None:
+        validate_context_key(key)
+        self.state.contexts[key] = context
+        self.checkpoint()
+
+    def _resolve_animal(self, animal: str | None) -> Animal:
+        if animal is None:
+            return self.require_current_animal()
+        try:
+            return self.state.animals[animal]
+        except KeyError as error:
+            raise ValueError(f"animal {animal} not found") from error
+
+    def set_animal_context(
+        self,
+        key: str,
+        context: BaseModel,
+        *,
+        animal: str | None = None,
+    ) -> None:
+        validate_context_key(key)
+        self._resolve_animal(animal).contexts[key] = context
+        self.checkpoint()
+
+    def set_stage_context(
+        self,
+        key: str,
+        context: BaseModel,
+        *,
+        animal: str | None = None,
+        stage: str | None = None,
+    ) -> None:
+        stage_state = self._resolve_stage(animal=animal, stage=stage)
+        validate_context_key(key)
+        stage_state.contexts[key] = context
+        self.checkpoint()
+
+    def _start_animal_session(self, animal: Animal) -> None:
+        if animal.current_animal_session is not None:
+            raise ValueError("Animal session is already started")
+
+        if animal.initial_stage is None:
+            animal.initial_stage = StageSnapshot.from_state(animal.current_stage)
+        animal.final_stage = None
+
+        animal_session = AnimalSessionState(session_id=len(animal.animal_sessions) + 1)
+        animal.current_animal_session = animal_session
+        animal.animal_sessions.append(animal_session)
+
+    def _end_animal_session(self, animal: Animal) -> None:
+        animal_session = animal.current_animal_session
+        if animal_session is None:
+            raise ValueError("Animal session is not started")
+
+        animal_session.end_at = datetime.now(UTC)
+        animal.current_animal_session = None
+        animal.final_stage = StageSnapshot.from_state(animal.current_stage)
+
+    def _resolve_stage(
+        self,
+        *,
+        animal: str | None,
+        stage: str | None,
+    ) -> StageState:
+        animal_state = self._resolve_animal(animal)
+        if stage is None:
+            return animal_state.current_stage
+        try:
+            return animal_state.stages[stage]
+        except KeyError as error:
+            raise ValueError(f"stage {stage} not found") from error
 
 
 class Options(BaseModel):
-    mxbis: list[str] = Field(default_factory=list[str], frozen=True)
-    experimenter: list[str] = Field(default_factory=list[str], frozen=True)
-    animals: dict[str, str] = Field(default_factory=dict[str, str], frozen=True)
+    mxbis: list[str] = Field(default_factory=list, frozen=True)
+    experimenter: list[str] = Field(default_factory=list, frozen=True)
+    animals: dict[str, str] = Field(default_factory=dict, frozen=True)

--- a/src/mxbiflow/scene/scene_manager.py
+++ b/src/mxbiflow/scene/scene_manager.py
@@ -74,12 +74,13 @@ class SceneManager:
         self.current = next_scene
         next_scene.start()
 
-    def apply_pending(self) -> None:
+    def apply_pending(self) -> bool:
         if self._pending is None:
-            return
+            return False
         next_scene = self._pending
         self._pending = None
         self._switch(next_scene)
+        return True
 
     def handle_event(self, event: Event) -> None:
         if self.current:

--- a/src/mxbiflow/ui/experiment_panel.py
+++ b/src/mxbiflow/ui/experiment_panel.py
@@ -108,14 +108,17 @@ class ExperimentPanel(QMainWindow):
     def result(self) -> SessionConfig:
         session_config = self.group_config.result()
         scene_result = self.group_scene.result()
-        session_config.default_scene = scene_result.default_scene
-        session_config.unknown_animal_fallback = scene_result.unknown_animal_fallback
-        session_config.unknown_animal_fallback_animal = (
-            scene_result.unknown_animal_fallback_animal
+        data = session_config.model_dump()
+        data.update(
+            default_scene=scene_result.default_scene,
+            unknown_animal_fallback=scene_result.unknown_animal_fallback,
+            unknown_animal_fallback_animal=(
+                scene_result.unknown_animal_fallback_animal
+            ),
+            fault_fallback=scene_result.fault_fallback,
+            animals=self.group_animals.result(),
         )
-        session_config.fault_fallback = scene_result.fault_fallback
-        session_config.animals = self.group_animals.result()
-        return session_config
+        return SessionConfig.model_validate(data)
 
     def _fallback_animal_options(self) -> list[str]:
         names = list(self._options.value.animals.values())

--- a/tests/test_backup_ui.py
+++ b/tests/test_backup_ui.py
@@ -1,3 +1,5 @@
+# pyright: reportPrivateUsage=false
+
 import os
 import unittest
 from collections import deque

--- a/tests/test_data_logger.py
+++ b/tests/test_data_logger.py
@@ -4,11 +4,19 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from mxbiflow.infra.data_logger import DataLogger, DataLoggerType
-from mxbiflow.models.session import DailySessionIdStore, Session
+from mxbiflow.models.session import (
+    DailySessionIdStore,
+    Session,
+    SessionConfig,
+    SessionState,
+)
 
 
 def make_session(*, session_id: int = 7) -> Session:
-    return Session(session_id=session_id, note="")
+    return Session(
+        config=SessionConfig(),
+        state=SessionState(session_id=session_id),
+    )
 
 
 class SessionDataPathTests(unittest.TestCase):
@@ -26,8 +34,7 @@ class SessionDataPathTests(unittest.TestCase):
             self.assertEqual(session.session_id, 1)
             self.assertEqual(
                 session.data_path,
-                Path(session.start_at.strftime("%Y%m%d"))
-                / str(session.session_id),
+                Path(session.start_at.strftime("%Y%m%d")) / str(session.session_id),
             )
             assert session.data_path is not None
             self.assertFalse(session.data_path.is_absolute())
@@ -41,10 +48,12 @@ class SessionDataPathTests(unittest.TestCase):
             session = make_session()
             session.start(Path(directory) / "data")
 
-            payload = session.model_dump(mode="json")
+            payload = session.snapshot()
 
             assert session.data_path is not None
-            self.assertEqual(payload["data_path"], str(session.data_path))
+            state = payload["state"]
+            assert isinstance(state, dict)
+            self.assertEqual(state["data_path"], str(session.data_path))
 
 
 class DataLoggerTests(unittest.TestCase):
@@ -53,6 +62,8 @@ class DataLoggerTests(unittest.TestCase):
             session = make_session()
             session.start(Path(directory) / "data")
             assert session.data_path is not None
+            absolute_data_path = session.absolute_data_path
+            assert absolute_data_path is not None
 
             session_logger = DataLogger(
                 session=session,
@@ -67,11 +78,11 @@ class DataLoggerTests(unittest.TestCase):
 
             self.assertEqual(
                 session_logger.path,
-                session.absolute_data_path / "session.json",
+                absolute_data_path / "session.json",
             )
             self.assertEqual(
                 animal_logger.path,
-                session.absolute_data_path / "animal-1" / "trials.jsonl",
+                absolute_data_path / "animal-1" / "trials.jsonl",
             )
 
             session_logger.save({"session_id": session.session_id})

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,0 +1,369 @@
+import json
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from pydantic import BaseModel, ValidationError
+
+from mxbiflow.bootstrap import init_session
+from mxbiflow.models.animal import Animal, AnimalConfig, StageSnapshot, StageState
+from mxbiflow.models.session import (
+    Session,
+    SessionConfig,
+    SessionSnapshotStore,
+    SessionState,
+)
+
+
+class ExampleContext(BaseModel):
+    value: int
+
+
+class RecordingSnapshotStore(SessionSnapshotStore):
+    def __init__(self) -> None:
+        super().__init__(Path("unused.json"))
+        self.snapshots: list[dict[str, object]] = []
+
+    def save(self, snapshot: Mapping[str, object]) -> None:
+        self.snapshots.append(dict(snapshot))
+
+
+def make_session() -> Session:
+    animal_config = AnimalConfig(
+        rfid_id="rfid-1",
+        name="animal-1",
+        stage="vocalization_discriminate",
+        level=2,
+    )
+    stage = StageState(
+        stage_name=animal_config.stage,
+        initial_level=animal_config.level,
+        level=animal_config.level,
+    )
+    animal = Animal(
+        config=animal_config,
+        current_stage_name=stage.stage_name,
+        stages={stage.stage_name: stage},
+    )
+    config = SessionConfig(
+        experimenter="tester",
+        send_email=True,
+        sync_data=True,
+        animals=(animal_config,),
+    )
+    return Session(
+        config=config,
+        state=SessionState(animals={animal.name: animal}),
+    )
+
+
+class SessionModelTests(unittest.TestCase):
+    def test_bootstrap_reuses_animal_config(self) -> None:
+        animal_config = AnimalConfig(
+            rfid_id="rfid-1",
+            name="animal-1",
+            stage="vocalization_discriminate",
+            level=2,
+        )
+
+        with patch(
+            "mxbiflow.bootstrap.get_session_counter_path",
+            return_value=Path("unused-session-counter.json"),
+        ):
+            session = init_session(SessionConfig(animals=(animal_config,)))
+        animal = session.animals["animal-1"]
+
+        self.assertIs(animal.config, session.config.animals[0])
+        self.assertEqual(animal.rfid_id, "rfid-1")
+        self.assertEqual(animal.name, "animal-1")
+
+    def test_only_session_exposes_state_mutation_methods(self) -> None:
+        session = make_session()
+        animal = session.animals["animal-1"]
+        stage = animal.current_stage
+
+        for method in (
+            "start_animal_session",
+            "end_animal_session",
+            "set_current_stage",
+            "add_trial",
+            "level_up",
+            "level_down",
+            "set_context",
+        ):
+            self.assertFalse(hasattr(animal, method), method)
+
+        for method in ("add_trial", "level_up", "level_down", "set_context"):
+            self.assertFalse(hasattr(stage, method), method)
+
+        self.assertTrue(callable(session.add_trial))
+        self.assertTrue(callable(session.level_up))
+        self.assertTrue(callable(session.set_stage_context))
+
+    def test_computed_fields_expose_config_and_state(self) -> None:
+        session = make_session()
+        animal = session.animals["animal-1"]
+
+        self.assertEqual(session.experimenter, "tester")
+        self.assertTrue(session.send_email)
+        self.assertTrue(session.sync_data)
+        self.assertEqual(list(session.animals), ["animal-1"])
+        self.assertIsNone(session.current_animal)
+        with self.assertRaisesRegex(RuntimeError, "set_current_animal"):
+            session.require_current_animal()
+
+        session.set_current_animal("animal-1")
+        self.assertIs(session.require_current_animal(), animal)
+        self.assertEqual(animal.rfid_id, animal.config.rfid_id)
+        self.assertEqual(animal.name, animal.config.name)
+        self.assertNotIn("rfid_id", Animal.model_fields)
+        self.assertNotIn("name", Animal.model_fields)
+
+        with self.assertRaises(ValidationError):
+            session.config.experimenter = "changed"  # type: ignore[misc]
+        with self.assertRaises(ValidationError):
+            animal.config = AnimalConfig()  # type: ignore[misc]
+        with self.assertRaises(ValidationError):
+            animal.config.name = "changed"  # type: ignore[misc]
+
+    def test_snapshot_has_only_config_and_state_at_the_top_level(self) -> None:
+        session = make_session()
+
+        snapshot = session.snapshot()
+
+        self.assertEqual(set(snapshot), {"config", "state"})
+        state = snapshot["state"]
+        assert isinstance(state, dict)
+        animal = state["animals"]["animal-1"]
+        config = snapshot["config"]
+        assert isinstance(config, dict)
+        self.assertEqual(
+            config["animals"][0],
+            {
+                "rfid_id": "rfid-1",
+                "name": "animal-1",
+                "stage": "vocalization_discriminate",
+                "level": 2,
+            },
+        )
+        self.assertEqual(animal["rfid_id"], "rfid-1")
+        self.assertEqual(animal["name"], "animal-1")
+        self.assertNotIn("config", animal)
+        self.assertIn("stages", animal)
+        self.assertNotIn("stages_by_name", animal)
+        self.assertIsNone(animal["initial_stage"])
+        self.assertIsNone(animal["final_stage"])
+        self.assertIn("current_animal_session", animal)
+        self.assertNotIn("current_animal_session_state", animal)
+        self.assertIn("animal_sessions", animal)
+        self.assertNotIn("current_stage", animal)
+        self.assertNotIn("sessions", animal)
+
+    def test_stage_snapshots_capture_animal_session_boundaries(self) -> None:
+        session = make_session()
+        animal = session.animals["animal-1"]
+        stage = animal.current_stage
+        stage.contexts["stage.before"] = ExampleContext(value=1)
+
+        session.set_current_animal("animal-1")
+
+        initial_stage = animal.initial_stage
+        assert initial_stage is not None
+        self.assertEqual(initial_stage.stage_name, stage.stage_name)
+        self.assertEqual(initial_stage.stage_trial_id, 0)
+        self.assertEqual(initial_stage.level, 2)
+        self.assertEqual(
+            initial_stage.get_context("stage.before", ExampleContext),
+            ExampleContext(value=1),
+        )
+        with self.assertRaises(ValidationError):
+            initial_stage.level = 3  # type: ignore[misc]
+
+        context = stage.get_context("stage.before", ExampleContext)
+        assert context is not None
+        context.value = 2
+        session.add_trial()
+        session.level_up()
+        session.clear_current_animal()
+
+        self.assertIs(animal.initial_stage, initial_stage)
+        self.assertEqual(initial_stage.level, 2)
+        self.assertEqual(
+            initial_stage.get_context("stage.before", ExampleContext),
+            ExampleContext(value=1),
+        )
+
+        final_stage = animal.final_stage
+        assert final_stage is not None
+        self.assertEqual(final_stage.stage_trial_id, 1)
+        self.assertEqual(final_stage.level, 3)
+        self.assertEqual(
+            final_stage.get_context("stage.before", ExampleContext),
+            ExampleContext(value=2),
+        )
+
+        session.level_up(animal="animal-1", stage=stage.stage_name)
+        self.assertEqual(final_stage.level, 3)
+
+        session.set_current_animal("animal-1")
+        self.assertIsNone(animal.final_stage)
+        session.set_current_stage(
+            StageState(stage_name="second", initial_level=5, level=5)
+        )
+        session.clear_current_animal()
+
+        self.assertIs(animal.initial_stage, initial_stage)
+        assert animal.final_stage is not None
+        self.assertEqual(animal.final_stage.stage_name, "second")
+        self.assertEqual(animal.final_stage.level, 5)
+
+        snapshot = session.snapshot()
+        snapshot_state = snapshot["state"]
+        assert isinstance(snapshot_state, dict)
+        snapshot_animal = snapshot_state["animals"]["animal-1"]
+        self.assertEqual(snapshot_animal["initial_stage"]["level"], 2)
+        self.assertEqual(snapshot_animal["final_stage"]["stage_name"], "second")
+
+    def test_stage_snapshot_requires_complete_stage_data(self) -> None:
+        with self.assertRaises(ValidationError):
+            StageSnapshot(stage_name="stage")  # type: ignore[call-arg]
+
+    def test_lifecycle_and_context_changes_are_checkpointed(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            store = RecordingSnapshotStore()
+            session.set_snapshot_store(store)
+
+            session.start(Path(directory) / "data")
+            session.set_current_scene("idle")
+            session.set_current_animal("animal-1")
+            session.add_trial()
+            session.set_context("session.summary", ExampleContext(value=1))
+            session.set_animal_context("animal.summary", ExampleContext(value=2))
+            session.set_stage_context("stage.result", ExampleContext(value=3))
+            session.level_up()
+            session.clear_current_animal()
+            session.end()
+
+            self.assertEqual(len(store.snapshots), 10)
+            self.assertIsNone(session.current_animal)
+            self.assertIsNotNone(session.end_at)
+
+            animal = session.animals["animal-1"]
+            self.assertEqual(animal.trial_id, 1)
+            self.assertEqual(animal.current_stage.level, 3)
+            self.assertEqual(animal.current_stage.level_trial_id, 0)
+            self.assertEqual(len(animal.animal_sessions), 1)
+            self.assertIsNotNone(animal.animal_sessions[0].end_at)
+
+            self.assertEqual(
+                session.get_context("session.summary", ExampleContext),
+                ExampleContext(value=1),
+            )
+            self.assertEqual(
+                animal.get_context("animal.summary", ExampleContext),
+                ExampleContext(value=2),
+            )
+            self.assertEqual(
+                animal.current_stage.get_context("stage.result", ExampleContext),
+                ExampleContext(value=3),
+            )
+
+            stage_context = store.snapshots[-1]["state"]
+            assert isinstance(stage_context, dict)
+            self.assertEqual(
+                stage_context["animals"]["animal-1"]["stages"][
+                    "vocalization_discriminate"
+                ]["contexts"]["stage.result"],
+                {"value": 3},
+            )
+
+    def test_default_snapshot_store_writes_session_json(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            session.start(Path(directory) / "data")
+            session.set_current_animal("animal-1")
+            session.add_trial()
+
+            data_path = session.absolute_data_path
+            assert data_path is not None
+            payload = json.loads(
+                (data_path / "session.json").read_text(encoding="utf-8")
+            )
+
+            self.assertEqual(set(payload), {"config", "state"})
+            self.assertEqual(payload["state"]["current_animal_name"], "animal-1")
+            self.assertEqual(payload["state"]["animals"]["animal-1"]["trial_id"], 1)
+
+    def test_invalid_context_access_and_state_transitions_fail_explicitly(self) -> None:
+        session = make_session()
+
+        with self.assertRaisesRegex(ValueError, "context key"):
+            session.set_context("", ExampleContext(value=1))
+        with self.assertRaisesRegex(RuntimeError, "set_current_animal"):
+            session.add_trial()
+        with self.assertRaisesRegex(ValueError, "not found"):
+            session.set_current_animal("unknown")
+
+    def test_failed_and_unchanged_mutations_do_not_checkpoint(self) -> None:
+        session = make_session()
+        store = RecordingSnapshotStore()
+        session.set_snapshot_store(store)
+
+        session.set_current_scene("idle")
+        session.set_current_scene("idle")
+        self.assertEqual(len(store.snapshots), 1)
+
+        with self.assertRaisesRegex(RuntimeError, "set_current_animal"):
+            session.add_trial()
+        with self.assertRaisesRegex(ValueError, "not found"):
+            session.set_stage_context(
+                "stage.result",
+                ExampleContext(value=1),
+                animal="unknown",
+            )
+        self.assertEqual(len(store.snapshots), 1)
+
+        session.set_current_animal("animal-1")
+        stage = session.require_current_animal().current_stage
+        stage.level = 0
+        stage.level_trial_id = 4
+        checkpoint_count = len(store.snapshots)
+
+        with self.assertRaisesRegex(ValueError, "less than 0"):
+            session.level_down()
+
+        self.assertEqual(stage.level, 0)
+        self.assertEqual(stage.level_trial_id, 4)
+        self.assertEqual(len(store.snapshots), checkpoint_count)
+
+    def test_departed_animal_can_still_be_settled_explicitly(self) -> None:
+        session = make_session()
+        session.set_current_animal("animal-1")
+        session.clear_current_animal()
+
+        session.set_stage_context(
+            "stage.result",
+            ExampleContext(value=4),
+            animal="animal-1",
+            stage="vocalization_discriminate",
+        )
+        level = session.level_up(
+            animal="animal-1",
+            stage="vocalization_discriminate",
+        )
+
+        self.assertEqual(level, 3)
+        self.assertEqual(
+            session.animals["animal-1"].current_stage.get_context(
+                "stage.result",
+                ExampleContext,
+            ),
+            ExampleContext(value=4),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -841,7 +841,7 @@ wheels = [
 
 [[package]]
 name = "pymotego"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "/Users/ccccr/repo/projects/cogmote/cogmote/pymoteGO" }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
- centralize session mutations and persist config/state snapshots
- derive animal identity from immutable config and capture stage boundaries
- expand lifecycle, checkpoint, and serialization coverage