### PR TITLE
refactor(session): :recycle: map unknown events to an animal

### DIFF
--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -31,10 +31,6 @@ class Game:
         self._scene_manager = scene_manager
         if session.default_scene:
             self._scene_manager.default_scene = session.default_scene
-        if session.unknown_animal_fallback:
-            self._scene_manager.unknown_animal_fallback = (
-                session.unknown_animal_fallback
-            )
         if session.fault_fallback:
             self._scene_manager.fault_fallback = session.fault_fallback
 

--- a/src/mxbiflow/gameloop/scheduler.py
+++ b/src/mxbiflow/gameloop/scheduler.py
@@ -49,25 +49,7 @@ class Scheduler:
         self._scene_manager.switch(fallback)
 
     def _handle_unknown_animal(self) -> None:
-        fallback_animal = self._session.unknown_animal_fallback_animal
-        if fallback_animal:
-            if fallback_animal in self._session.animals:
-                self._set_current_animal(fallback_animal)
-            else:
-                logger.warning(
-                    "unknown_animal_fallback_animal is not in session animals: {}",
-                    fallback_animal,
-                )
-        else:
-            logger.warning(
-                "unknown_animal_fallback_animal is empty; current_animal remains unset"
-            )
-
-        fallback = self._scene_manager.unknown_animal_fallback
-        if isinstance(self._scene_manager.current, fallback):
-            return
-
-        self._scene_manager.switch(fallback)
+        self._set_current_animal(self._session.unknown_animal_as)
 
     def handle_event(self, event: Event) -> None:
         if event.type != EVT_DETECTOR:

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -14,6 +14,7 @@ from pydantic import (
     ValidationError,
     computed_field,
     field_serializer,
+    model_validator,
 )
 
 from .animal import (
@@ -38,8 +39,7 @@ class SessionConfig(BaseModel):
     note: str = Field(default="", max_length=1000)
 
     default_scene: str = ""
-    unknown_animal_fallback: str = ""
-    unknown_animal_fallback_animal: str = ""
+    unknown_animal_as: str = ""
     fault_fallback: str = ""
 
     hide_cursor: bool = False
@@ -47,6 +47,21 @@ class SessionConfig(BaseModel):
     auto_accept_timeout_seconds: int = Field(default=60, ge=0)
 
     animals: tuple[AnimalConfig, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_unknown_animal_as(self) -> SessionConfig:
+        if not self.animals:
+            return self
+
+        if not self.unknown_animal_as:
+            raise ValueError("unknown_animal_as must be set when animals are configured")
+
+        animal_names = {animal.name for animal in self.animals}
+        if self.unknown_animal_as not in animal_names:
+            raise ValueError(
+                "unknown_animal_as must match a configured animal name"
+            )
+        return self
 
 
 class SessionState(ContextState):
@@ -198,13 +213,8 @@ class Session(BaseModel):
 
     @computed_field
     @property
-    def unknown_animal_fallback(self) -> str:
-        return self.config.unknown_animal_fallback
-
-    @computed_field
-    @property
-    def unknown_animal_fallback_animal(self) -> str:
-        return self.config.unknown_animal_fallback_animal
+    def unknown_animal_as(self) -> str:
+        return self.config.unknown_animal_as
 
     @computed_field
     @property

--- a/src/mxbiflow/scene/scene_manager.py
+++ b/src/mxbiflow/scene/scene_manager.py
@@ -13,7 +13,6 @@ class SceneManager:
         self.current: Scene | None = None
         self._pending: Scene | None = None
         self._default_scene: type[Scene] = IDLE
-        self._unknown_animal_fallback: type[Scene] = IDLE
         self._fault_fallback: type[Scene] = IDLE
 
         self.register([IDLE])
@@ -43,14 +42,6 @@ class SceneManager:
     @default_scene.setter
     def default_scene(self, name: str) -> None:
         self._default_scene = self._scenes[name]
-
-    @property
-    def unknown_animal_fallback(self) -> type[Scene]:
-        return self._unknown_animal_fallback
-
-    @unknown_animal_fallback.setter
-    def unknown_animal_fallback(self, name: str) -> None:
-        self._unknown_animal_fallback = self._scenes[name]
 
     @property
     def fault_fallback(self) -> type[Scene]:

--- a/src/mxbiflow/ui/components/experiment_groups.py
+++ b/src/mxbiflow/ui/components/experiment_groups.py
@@ -100,8 +100,7 @@ class ExperimentConfigGroup(QGroupBox):
 
 class SceneSelection(NamedTuple):
     default_scene: str
-    unknown_animal_fallback: str
-    unknown_animal_fallback_animal: str
+    unknown_animal_as: str
     fault_fallback: str
 
 
@@ -123,18 +122,12 @@ class ExperimentSceneGroup(QGroupBox):
         self.combo_default_scene.addItems(stages)
         layout.addRow(label_default, self.combo_default_scene)
 
-        label_unknown = QLabel("unknown animal fallback", self)
-        self.combo_unknown_animal_fallback = QComboBox(self)
-        self.combo_unknown_animal_fallback.addItems(stages)
-        layout.addRow(label_unknown, self.combo_unknown_animal_fallback)
-
-        label_unknown_animal = QLabel("unknown fallback animal", self)
-        self.combo_unknown_animal_fallback_animal = QComboBox(self)
-        self.combo_unknown_animal_fallback_animal.addItem("")
-        self.combo_unknown_animal_fallback_animal.addItems(animals)
+        label_unknown_animal = QLabel("unknown animal as", self)
+        self.combo_unknown_animal_as = QComboBox(self)
+        self.combo_unknown_animal_as.addItems(animals)
         layout.addRow(
             label_unknown_animal,
-            self.combo_unknown_animal_fallback_animal,
+            self.combo_unknown_animal_as,
         )
 
         label_fault = QLabel("fault fallback", self)
@@ -145,31 +138,17 @@ class ExperimentSceneGroup(QGroupBox):
     def load_config(self, config: SessionConfig) -> None:
         if config.default_scene:
             self.combo_default_scene.setCurrentText(config.default_scene)
-        if config.unknown_animal_fallback:
-            self.combo_unknown_animal_fallback.setCurrentText(
-                config.unknown_animal_fallback
-            )
-        if config.unknown_animal_fallback_animal:
-            if (
-                self.combo_unknown_animal_fallback_animal.findText(
-                    config.unknown_animal_fallback_animal
-                )
-                < 0
-            ):
-                self.combo_unknown_animal_fallback_animal.addItem(
-                    config.unknown_animal_fallback_animal
-                )
-            self.combo_unknown_animal_fallback_animal.setCurrentText(
-                config.unknown_animal_fallback_animal
-            )
+        if config.unknown_animal_as:
+            if self.combo_unknown_animal_as.findText(config.unknown_animal_as) < 0:
+                self.combo_unknown_animal_as.addItem(config.unknown_animal_as)
+            self.combo_unknown_animal_as.setCurrentText(config.unknown_animal_as)
         if config.fault_fallback:
             self.combo_fault_fallback.setCurrentText(config.fault_fallback)
 
     def result(self) -> SceneSelection:
         return SceneSelection(
             default_scene=self.combo_default_scene.currentText(),
-            unknown_animal_fallback=self.combo_unknown_animal_fallback.currentText(),
-            unknown_animal_fallback_animal=self.combo_unknown_animal_fallback_animal.currentText(),
+            unknown_animal_as=self.combo_unknown_animal_as.currentText(),
             fault_fallback=self.combo_fault_fallback.currentText(),
         )
 

--- a/src/mxbiflow/ui/experiment_panel.py
+++ b/src/mxbiflow/ui/experiment_panel.py
@@ -111,10 +111,7 @@ class ExperimentPanel(QMainWindow):
         data = session_config.model_dump()
         data.update(
             default_scene=scene_result.default_scene,
-            unknown_animal_fallback=scene_result.unknown_animal_fallback,
-            unknown_animal_fallback_animal=(
-                scene_result.unknown_animal_fallback_animal
-            ),
+            unknown_animal_as=scene_result.unknown_animal_as,
             fault_fallback=scene_result.fault_fallback,
             animals=self.group_animals.result(),
         )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,67 @@
+import unittest
+
+from pygame import Event, Surface
+from pymxbi.detector.detector import DetectorEvent
+
+from mxbiflow.gameloop.detector_bridge import EVT_DETECTOR, DetectorMsg
+from mxbiflow.gameloop.scheduler import Scheduler
+from mxbiflow.models.animal import Animal, AnimalConfig, StageState
+from mxbiflow.models.session import Session, SessionConfig, SessionState
+from mxbiflow.scene import SceneManager
+from mxbiflow.scene.scene import Scene
+
+
+class TargetStage(Scene):
+    def start(self) -> None:
+        self._running = True
+
+    def quit(self) -> None:
+        self._running = False
+
+    def handle_event(self, event: Event) -> None:
+        pass
+
+    def update(self, dt_s: float) -> None:
+        pass
+
+    def draw(self, screen: Surface) -> None:
+        pass
+
+
+class SchedulerTests(unittest.TestCase):
+    def test_unknown_animal_uses_configured_animal_stage(self) -> None:
+        animal_config = AnimalConfig(name="fallback", stage="targetstage")
+        animal = Animal(
+            config=animal_config,
+            current_stage_name="targetstage",
+            stages={"targetstage": StageState(stage_name="targetstage")},
+        )
+        session = Session(
+            config=SessionConfig(
+                unknown_animal_as=animal_config.name,
+                animals=(animal_config,),
+            ),
+            state=SessionState(animals={animal.name: animal}),
+        )
+        scene_manager = SceneManager()
+        scene_manager.register([TargetStage])
+        scheduler = Scheduler(session, scene_manager)
+
+        scheduler.handle_event(
+            Event(
+                EVT_DETECTOR,
+                msg=DetectorMsg(
+                    kind=DetectorEvent.UNKNOWN_ANIMAL_ENTERED,
+                    animal="unrecognized-rfid",
+                ),
+            )
+        )
+        scheduler.update()
+        scene_manager.apply_pending()
+
+        self.assertIs(session.current_animal, animal)
+        self.assertIsInstance(scene_manager.current, TargetStage)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -51,6 +51,7 @@ def make_session() -> Session:
         experimenter="tester",
         send_email=True,
         sync_data=True,
+        unknown_animal_as=animal_config.name,
         animals=(animal_config,),
     )
     return Session(
@@ -60,6 +61,41 @@ def make_session() -> Session:
 
 
 class SessionModelTests(unittest.TestCase):
+    def test_session_config_without_animals_allows_empty_unknown_mapping(
+        self,
+    ) -> None:
+        config = SessionConfig()
+
+        self.assertEqual(config.unknown_animal_as, "")
+
+    def test_session_config_requires_valid_unknown_animal_mapping(self) -> None:
+        animal = AnimalConfig(name="animal-1")
+
+        with self.assertRaisesRegex(ValidationError, "unknown_animal_as must be set"):
+            SessionConfig(animals=(animal,))
+        with self.assertRaisesRegex(
+            ValidationError,
+            "unknown_animal_as must match a configured animal name",
+        ):
+            SessionConfig(unknown_animal_as="missing", animals=(animal,))
+
+        config = SessionConfig(
+            unknown_animal_as=animal.name,
+            animals=(animal,),
+        )
+        self.assertEqual(config.unknown_animal_as, animal.name)
+
+    def test_legacy_unknown_animal_field_does_not_configure_mapping(self) -> None:
+        animal = AnimalConfig(name="animal-1")
+
+        with self.assertRaisesRegex(ValidationError, "unknown_animal_as must be set"):
+            SessionConfig.model_validate(
+                {
+                    "unknown_animal_fallback_animal": animal.name,
+                    "animals": [animal],
+                }
+            )
+
     def test_bootstrap_reuses_animal_config(self) -> None:
         animal_config = AnimalConfig(
             rfid_id="rfid-1",
@@ -72,7 +108,12 @@ class SessionModelTests(unittest.TestCase):
             "mxbiflow.bootstrap.get_session_counter_path",
             return_value=Path("unused-session-counter.json"),
         ):
-            session = init_session(SessionConfig(animals=(animal_config,)))
+            session = init_session(
+                SessionConfig(
+                    unknown_animal_as=animal_config.name,
+                    animals=(animal_config,),
+                )
+            )
         animal = session.animals["animal-1"]
 
         self.assertIs(animal.config, session.config.animals[0])
@@ -139,6 +180,9 @@ class SessionModelTests(unittest.TestCase):
         animal = state["animals"]["animal-1"]
         config = snapshot["config"]
         assert isinstance(config, dict)
+        self.assertEqual(config["unknown_animal_as"], "animal-1")
+        self.assertNotIn("unknown_animal_fallback", config)
+        self.assertNotIn("unknown_animal_fallback_animal", config)
         self.assertEqual(
             config["animals"][0],
             {


### PR DESCRIPTION
- replace scene fallback settings with validated unknown_animal_as mapping
- route unknown detections through the animal's current stage scheduler flow
- update experiment UI and add configuration and scheduler coverage