### PR TITLE
refactor(state): unify runtime persistence

### DIFF
--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -7,9 +7,9 @@ from pymxbi.mxbi.factory import MXBIModel
 from mxbiflow import set_base_path
 from mxbiflow.bootstrap import init_gameloop
 from mxbiflow.core.config_store import ConfigStore
-from mxbiflow.core.path import get_email_state_path, get_mxbi_config_path
+from mxbiflow.core.path import get_mxbi_config_path, get_runtime_state_path
 from mxbiflow.infra.post_processing import HtmlComposer, session_overview, summarize
-from mxbiflow.models.session import EmailSendStateStore
+from mxbiflow.models.session import RuntimeStateStore
 from mxbiflow.scene import SceneManager
 from mxbiflow.scene.idle.idle import IDLE
 from mxbiflow.ui.wizard import config_wizard
@@ -42,16 +42,16 @@ def main() -> None:
     html = composer.html
 
     mxbi_config = ConfigStore(get_mxbi_config_path(), MXBIModel).value
-    email_store = EmailSendStateStore(get_email_state_path())
-    prev_state = email_store.load()
+    runtime_store = RuntimeStateStore(get_runtime_state_path())
+    previous_message_id = runtime_store.email_message_id
 
     with EmailClient() as client:
         result = client.send(
             subject=f"{mxbi_config.mxbi_id} Daily Report",
             html_body=html,
-            in_reply_to=prev_state.message_id if prev_state.message_id else None,
+            in_reply_to=previous_message_id or None,
         )
-        email_store.save(result.message_id)
+        runtime_store.save_email_message_id(result.message_id)
 
 
 if __name__ == "__main__":

--- a/src/mxbiflow/bootstrap.py
+++ b/src/mxbiflow/bootstrap.py
@@ -6,12 +6,12 @@ from .core.config_store import ConfigStore
 from .core.path import (
     get_config_session_path,
     get_mxbi_config_path,
-    get_session_counter_path,
+    get_runtime_state_path,
 )
 from .gameloop.detector_bridge import DetectorBridge
 from .gameloop.game import Game
 from .models.animal import Animal, StageState
-from .models.session import DailySessionIdStore, Session, SessionConfig, SessionState
+from .models.session import RuntimeStateStore, Session, SessionConfig, SessionState
 from .scene import SceneManager
 
 
@@ -59,7 +59,7 @@ def build_mxbi() -> pymxbi.MXBI:
 
 
 def init_session(session_config: SessionConfig) -> Session:
-    store = DailySessionIdStore(get_session_counter_path())
+    store = RuntimeStateStore(get_runtime_state_path())
 
     animal_dict: dict[str, Animal] = {}
     for animal_config in session_config.animals:

--- a/src/mxbiflow/core/path.py
+++ b/src/mxbiflow/core/path.py
@@ -80,9 +80,5 @@ def get_internal_state_path() -> Path:
     return get_base_path() / ".mxbiflow" / "state"
 
 
-def get_session_counter_path() -> Path:
-    return get_internal_state_path() / "session_counter.json"
-
-
-def get_email_state_path() -> Path:
-    return get_internal_state_path() / "email_state.json"
+def get_runtime_state_path() -> Path:
+    return get_internal_state_path() / "runtime.json"

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -79,14 +79,18 @@ class SessionState(ContextState):
         return value.astimezone().isoformat(timespec="microseconds")
 
 
-class DailySessionCounter(BaseModel):
+class SessionRuntimeState(BaseModel):
     day: str = Field(default_factory=lambda: datetime.now(UTC).date().isoformat())
     last_session_id: int = Field(default=0, ge=0)
 
 
-class EmailSendState(BaseModel):
-    sent_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+class EmailRuntimeState(BaseModel):
     message_id: str = ""
+
+
+class RuntimeState(BaseModel):
+    session: SessionRuntimeState = Field(default_factory=SessionRuntimeState)
+    email: EmailRuntimeState = Field(default_factory=EmailRuntimeState)
 
 
 def _atomic_write(path: Path, text: str) -> None:
@@ -111,56 +115,45 @@ def _atomic_write(path: Path, text: str) -> None:
 
 
 @dataclass
-class DailySessionIdStore:
+class RuntimeStateStore:
     path: Path
 
-    def _today_local(self) -> str:
+    def _today(self) -> str:
         return datetime.now(UTC).date().isoformat()
 
-    def _load(self) -> DailySessionCounter:
+    def _load(self) -> RuntimeState:
         if not self.path.exists():
-            return DailySessionCounter()
+            return RuntimeState()
 
         try:
-            return DailySessionCounter.model_validate_json(self.path.read_text())
+            return RuntimeState.model_validate_json(self.path.read_text())
         except ValueError, ValidationError:
-            return DailySessionCounter()
+            return RuntimeState()
+
+    def _save(self, state: RuntimeState) -> None:
+        _atomic_write(self.path, state.model_dump_json())
 
     @property
     def session_id(self) -> int:
-        today = self._today_local()
-        data = self._load()
+        today = self._today()
+        state = self._load()
 
-        if data.day != today:
-            data.day = today
-            data.last_session_id = 0
+        if state.session.day != today:
+            state.session.day = today
+            state.session.last_session_id = 0
 
-        data.last_session_id += 1
-        _atomic_write(self.path, data.model_dump_json())
-        return data.last_session_id
+        state.session.last_session_id += 1
+        self._save(state)
+        return state.session.last_session_id
 
+    @property
+    def email_message_id(self) -> str:
+        return self._load().email.message_id
 
-@dataclass
-class EmailSendStateStore:
-    path: Path
-
-    def _load(self) -> EmailSendState:
-        if not self.path.exists():
-            return EmailSendState()
-
-        try:
-            return EmailSendState.model_validate_json(self.path.read_text())
-        except ValueError, ValidationError:
-            return EmailSendState()
-
-    def load(self) -> EmailSendState:
-        return self._load()
-
-    def save(self, message_id: str) -> None:
-        _atomic_write(
-            self.path,
-            EmailSendState(message_id=message_id).model_dump_json(),
-        )
+    def save_email_message_id(self, message_id: str) -> None:
+        state = self._load()
+        state.email.message_id = message_id
+        self._save(state)
 
 
 @dataclass
@@ -176,7 +169,7 @@ class Session(BaseModel):
     config: SessionConfig
     state: SessionState
 
-    _session_store: DailySessionIdStore | None = PrivateAttr(default=None)
+    _session_store: RuntimeStateStore | None = PrivateAttr(default=None)
     _snapshot_store: SessionSnapshotStore | None = PrivateAttr(default=None)
     _data_root: Path | None = PrivateAttr(default=None)
 
@@ -282,7 +275,7 @@ class Session(BaseModel):
             return None
         return self._data_root / self.state.data_path
 
-    def set_session_store(self, store: DailySessionIdStore) -> None:
+    def set_session_store(self, store: RuntimeStateStore) -> None:
         self._session_store = store
 
     def set_snapshot_store(self, store: SessionSnapshotStore) -> None:

--- a/tests/test_data_logger.py
+++ b/tests/test_data_logger.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryDirectory
 
 from mxbiflow.infra.data_logger import DataLogger, DataLoggerType
 from mxbiflow.models.session import (
-    DailySessionIdStore,
+    RuntimeStateStore,
     Session,
     SessionConfig,
     SessionState,
@@ -25,7 +25,7 @@ class SessionDataPathTests(unittest.TestCase):
             data_root = Path(directory) / "data"
             session = make_session(session_id=0)
             session.set_session_store(
-                DailySessionIdStore(Path(directory) / "state" / "counter.json")
+                RuntimeStateStore(Path(directory) / "state" / "runtime.json")
             )
 
             session.start(data_root)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -10,8 +10,12 @@ from pydantic import BaseModel, ValidationError
 from mxbiflow.bootstrap import init_session
 from mxbiflow.models.animal import Animal, AnimalConfig, StageSnapshot, StageState
 from mxbiflow.models.session import (
+    EmailRuntimeState,
+    RuntimeState,
+    RuntimeStateStore,
     Session,
     SessionConfig,
+    SessionRuntimeState,
     SessionSnapshotStore,
     SessionState,
 )
@@ -60,6 +64,76 @@ def make_session() -> Session:
     )
 
 
+class RuntimeStateStoreTests(unittest.TestCase):
+    def test_domains_share_one_file_without_overwriting_each_other(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "state" / "runtime.json"
+            store = RuntimeStateStore(path)
+
+            self.assertEqual(store.session_id, 1)
+            store.save_email_message_id("message-1")
+            self.assertEqual(store.session_id, 2)
+
+            state = RuntimeState.model_validate_json(path.read_text(encoding="utf-8"))
+            self.assertEqual(state.session.last_session_id, 2)
+            self.assertEqual(state.email.message_id, "message-1")
+            self.assertEqual(RuntimeStateStore(path).email_message_id, "message-1")
+
+    def test_session_counter_resets_on_a_new_day(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "runtime.json"
+            path.write_text(
+                RuntimeState(
+                    session=SessionRuntimeState(
+                        day="2000-01-01",
+                        last_session_id=9,
+                    ),
+                    email=EmailRuntimeState(message_id="message-1"),
+                ).model_dump_json(),
+                encoding="utf-8",
+            )
+
+            store = RuntimeStateStore(path)
+
+            self.assertEqual(store.session_id, 1)
+            self.assertEqual(store.email_message_id, "message-1")
+
+    def test_missing_or_invalid_file_uses_default_state(self) -> None:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "runtime.json"
+            store = RuntimeStateStore(path)
+
+            self.assertEqual(store.email_message_id, "")
+
+            path.write_text("invalid", encoding="utf-8")
+            self.assertEqual(store.email_message_id, "")
+            self.assertEqual(store.session_id, 1)
+
+    def test_legacy_state_files_are_ignored(self) -> None:
+        with TemporaryDirectory() as directory:
+            state_dir = Path(directory) / "state"
+            state_dir.mkdir()
+            (state_dir / "session_counter.json").write_text(
+                '{"day":"2099-01-01","last_session_id":99}',
+                encoding="utf-8",
+            )
+            (state_dir / "email_state.json").write_text(
+                '{"message_id":"legacy-message"}',
+                encoding="utf-8",
+            )
+            runtime_path = state_dir / "runtime.json"
+            store = RuntimeStateStore(runtime_path)
+
+            self.assertEqual(store.email_message_id, "")
+            self.assertEqual(store.session_id, 1)
+
+            state = RuntimeState.model_validate_json(
+                runtime_path.read_text(encoding="utf-8")
+            )
+            self.assertEqual(state.session.last_session_id, 1)
+            self.assertEqual(state.email.message_id, "")
+
+
 class SessionModelTests(unittest.TestCase):
     def test_session_config_without_animals_allows_empty_unknown_mapping(
         self,
@@ -105,8 +179,8 @@ class SessionModelTests(unittest.TestCase):
         )
 
         with patch(
-            "mxbiflow.bootstrap.get_session_counter_path",
-            return_value=Path("unused-session-counter.json"),
+            "mxbiflow.bootstrap.get_runtime_state_path",
+            return_value=Path("unused-runtime.json"),
         ):
             session = init_session(
                 SessionConfig(


### PR DESCRIPTION
## Summary

- combine daily session counters and email threading state in one `runtime.json`
- group persisted data by `session` and `email` domains
- replace the two domain-specific stores with `RuntimeStateStore`
- remove unused email send timestamps and legacy path APIs

## Why

The two small pieces of internal runtime state used separate JSON files and duplicated loading, recovery, and atomic write behavior. A single domain-grouped state file keeps persistence explicit while reducing storage and implementation overhead.

## Impact

New runtime state is written to `.mxbiflow/state/runtime.json`. Existing `session_counter.json` and `email_state.json` files are intentionally ignored and are not deleted or migrated.

## Validation

- `uv run python -m unittest discover -s tests -v` (45 tests)
- `uv run pyright`
- targeted Ruff checks
- `git diff --check`
