### PR TITLE
feat(api): expose experiment scaffold API

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ mxbiflow provides the core infrastructure for cognitive and behavioral experimen
 Implement your experiment as a set of scenes, register them, and launch:
 
 ```python
-from mxbiflow import set_base_path
-from mxbiflow.scene import SceneManager
-from mxbiflow.wizard import config_wizard, init_gameloop
+from pathlib import Path
+
+from mxbiflow import SceneManager, init_gameloop, set_base_path
+from mxbiflow.ui.wizard import config_wizard
+
+set_base_path(Path.cwd())
 
 scene_manager = SceneManager()
 scene_manager.register([IDLE, Detect, Discriminate])

--- a/src/mxbiflow/__init__.py
+++ b/src/mxbiflow/__init__.py
@@ -1,9 +1,14 @@
+from .bootstrap import init_gameloop
 from .core.context import MXBIFlow, get_mxbiflow
 from .core.path import get_base_path, set_base_path
+from .scene import Scene, SceneManager
 
 __all__ = [
     "MXBIFlow",
+    "Scene",
+    "SceneManager",
     "get_base_path",
     "get_mxbiflow",
+    "init_gameloop",
     "set_base_path",
 ]

--- a/src/mxbiflow/scene/idle/idle.py
+++ b/src/mxbiflow/scene/idle/idle.py
@@ -5,9 +5,9 @@ from typing import ClassVar
 
 from pygame import Event, Rect, Surface, image, transform
 
-from mxbiflow import get_mxbiflow
-from mxbiflow.assets import create_background
-from mxbiflow.scene import Scene
+from ...assets import create_background
+from ...core.context import get_mxbiflow
+from ..scene import Scene
 
 ASSETS_PATH = Path(__file__).parent / "assets"
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,59 @@
+import subprocess
+import sys
+import unittest
+
+import mxbiflow
+from mxbiflow.bootstrap import init_gameloop
+from mxbiflow.core.context import MXBIFlow, get_mxbiflow
+from mxbiflow.core.path import get_base_path, set_base_path
+from mxbiflow.scene import Scene, SceneManager
+
+
+class PublicApiTests(unittest.TestCase):
+    def test_top_level_exports_are_explicit(self) -> None:
+        expected_exports = {
+            "MXBIFlow",
+            "Scene",
+            "SceneManager",
+            "get_base_path",
+            "get_mxbiflow",
+            "init_gameloop",
+            "set_base_path",
+        }
+
+        self.assertEqual(set(mxbiflow.__all__), expected_exports)
+        self.assertIs(mxbiflow.MXBIFlow, MXBIFlow)
+        self.assertIs(mxbiflow.Scene, Scene)
+        self.assertIs(mxbiflow.SceneManager, SceneManager)
+        self.assertIs(mxbiflow.get_base_path, get_base_path)
+        self.assertIs(mxbiflow.get_mxbiflow, get_mxbiflow)
+        self.assertIs(mxbiflow.init_gameloop, init_gameloop)
+        self.assertIs(mxbiflow.set_base_path, set_base_path)
+
+    def test_top_level_api_imports_in_fresh_process_without_ui(self) -> None:
+        code = """
+import sys
+from mxbiflow import (
+    MXBIFlow,
+    Scene,
+    SceneManager,
+    get_base_path,
+    get_mxbiflow,
+    init_gameloop,
+    set_base_path,
+)
+assert "mxbiflow.ui" not in sys.modules
+"""
+
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- export scene and game-loop entry points from the package root
- avoid package initialization cycles in the idle scene
- document and test the supported top-level interface

## Validation

- 47 unit tests passed
- Pyright passed with 0 errors
- Ruff passed for changed Python files
- git diff --check passed