### PR TITLE
refactor(ui): simplify sequential dialog flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ mxbiflow provides the core infrastructure for cognitive and behavioral experimen
 ┌─────────────────────────────────────────────────────────┐
 │                       mxbiflow                          │
 │                                                         │
-│  Wizard (PySide6)          Game Loop (pygame-ce)        │
+│  Dialog Flow (PySide6)     Game Loop (pygame-ce)        │
 │  ┌────────────────┐         ┌───────────────────┐       │
 │  │ MXBIPanel      │         │ SceneManager      │       │
 │  │ ExperimentPanel│ ──────▶ │   ├─ Scene A      │       │
@@ -43,14 +43,16 @@ Implement your experiment as a set of scenes, register them, and launch:
 from pathlib import Path
 
 from mxbiflow import SceneManager, init_gameloop, set_base_path
-from mxbiflow.ui.wizard import config_wizard
+from mxbiflow.ui import run_wizard
 
 set_base_path(Path.cwd())
 
 scene_manager = SceneManager()
 scene_manager.register([IDLE, Detect, Discriminate])
 
-config_wizard(scene_manager)
+if not run_wizard(scene_manager):
+    raise SystemExit(0)
+
 game = init_gameloop(scene_manager, max_fps=120)
 game.play()
 ```

--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -12,7 +12,7 @@ from mxbiflow.infra.post_processing import HtmlComposer, session_overview, summa
 from mxbiflow.models.session import RuntimeStateStore
 from mxbiflow.scene import SceneManager
 from mxbiflow.scene.idle.idle import IDLE
-from mxbiflow.ui.wizard import config_wizard
+from mxbiflow.ui import run_wizard
 
 
 def main() -> None:
@@ -21,7 +21,8 @@ def main() -> None:
     scene_manager = SceneManager()
     scene_manager.register([IDLE])
 
-    config_wizard(scene_manager)
+    if not run_wizard(scene_manager):
+        return
 
     game = init_gameloop(scene_manager)
     game.play()

--- a/src/mxbiflow/ui/__init__.py
+++ b/src/mxbiflow/ui/__init__.py
@@ -1,3 +1,12 @@
-from .backup import run_backup
+from .backup import BackupPanel, run_backup
+from .experiment_panel import ExperimentPanel
+from .mxbi_panel import MXBIPanel
+from .wizard import run_wizard
 
-__all__ = ["run_backup"]
+__all__ = [
+    "BackupPanel",
+    "ExperimentPanel",
+    "MXBIPanel",
+    "run_backup",
+    "run_wizard",
+]

--- a/src/mxbiflow/ui/application.py
+++ b/src/mxbiflow/ui/application.py
@@ -1,0 +1,15 @@
+import sys
+
+from PySide6.QtWidgets import QApplication
+
+
+def require_application() -> QApplication:
+    """Return a Qt application configured for sequential dialogs."""
+    application = QApplication.instance()
+    if application is None:
+        application = QApplication(sys.argv)
+    if not isinstance(application, QApplication):
+        raise TypeError("The active Qt application is not a QApplication")
+
+    application.setQuitOnLastWindowClosed(False)
+    return application

--- a/src/mxbiflow/ui/backup.py
+++ b/src/mxbiflow/ui/backup.py
@@ -1,5 +1,3 @@
-import sys
-
 from pymotego import (
     BackupDestination,
     BackupSource,
@@ -9,7 +7,6 @@ from pymotego import (
 from PySide6.QtCore import QEvent, QObject, Qt, QTimer
 from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import (
-    QApplication,
     QDialog,
     QHBoxLayout,
     QLabel,
@@ -20,6 +17,7 @@ from PySide6.QtWidgets import (
 )
 
 from ..infra.backup import BackupTaskRunner
+from .application import require_application
 
 _REFRESH_INTERVAL_MS = 250
 _SUCCESS_AUTO_CLOSE_MS = 10_000
@@ -35,54 +33,34 @@ def run_backup(
     success_auto_close_ms: int = _SUCCESS_AUTO_CLOSE_MS,
 ) -> None:
     """Create a backup and show a blocking progress dialog."""
-    runner = BackupTaskRunner(
+    _application = require_application()
+    BackupPanel(
+        source,
+        destination,
         poll_interval_s=poll_interval_s,
         max_attempts=max_attempts,
-    )
-    runner.start(source, destination)
-    _show_progress_dialog(
-        runner,
         refresh_interval_ms=refresh_interval_ms,
         success_auto_close_ms=success_auto_close_ms,
-    )
+    ).exec()
 
 
-def _show_progress_dialog(
-    runner: BackupTaskRunner,
-    *,
-    refresh_interval_ms: int,
-    success_auto_close_ms: int,
-) -> None:
-    application = _require_application()
-    dialog = _BackupProgressDialog(
-        runner,
-        refresh_interval_ms=refresh_interval_ms,
-        success_auto_close_ms=success_auto_close_ms,
-    )
-    dialog.finished.connect(application.quit)
-    dialog.show()
-    application.exec()
-
-
-def _require_application() -> QApplication:
-    application = QApplication.instance()
-    if application is None:
-        application = QApplication(sys.argv)
-    if not isinstance(application, QApplication):
-        raise TypeError("The active Qt application is not a QApplication")
-    return application
-
-
-class _BackupProgressDialog(QDialog):
+class BackupPanel(QDialog):
     def __init__(
         self,
-        runner: BackupTaskRunner,
+        source: BackupSource,
+        destination: BackupDestination,
         *,
+        poll_interval_s: float = 1.0,
+        max_attempts: int = 3,
         refresh_interval_ms: int = _REFRESH_INTERVAL_MS,
         success_auto_close_ms: int = _SUCCESS_AUTO_CLOSE_MS,
     ) -> None:
         super().__init__()
-        self._runner = runner
+        self._runner = BackupTaskRunner(
+            poll_interval_s=poll_interval_s,
+            max_attempts=max_attempts,
+        )
+        self._runner.start(source, destination)
         self._can_close = False
         self._terminal_state_shown = False
         self._success_auto_close_ms = success_auto_close_ms

--- a/src/mxbiflow/ui/experiment_panel.py
+++ b/src/mxbiflow/ui/experiment_panel.py
@@ -1,11 +1,10 @@
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QCloseEvent, QShowEvent
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import (
+    QDialog,
     QGridLayout,
-    QMainWindow,
     QPushButton,
     QVBoxLayout,
-    QWidget,
 )
 
 from ..core.config_store import ConfigStore
@@ -25,24 +24,16 @@ from .components.experiment_groups import (
 )
 
 
-class ExperimentPanel(QMainWindow):
-    accepted = Signal()
-    rejected = Signal()
-
+class ExperimentPanel(QDialog):
     def __init__(self, scene_manager: SceneManager) -> None:
         super().__init__()
-        self._accepted = False
         self._config = ConfigStore(get_config_session_path(), SessionConfig)
         self._options = ConfigStore(get_options_session_path(), Options)
         self._stage_level_tables = scene_manager.stage_level_tables
 
         self.setWindowTitle("Experiment Panel")
 
-        central_widget = QWidget(self)
-        self.setCentralWidget(central_widget)
-
         layout_main = QVBoxLayout(self)
-        central_widget.setLayout(layout_main)
 
         self.group_config = ExperimentConfigGroup(
             self, self._options.value.experimenter
@@ -67,7 +58,7 @@ class ExperimentPanel(QMainWindow):
         self.combo_reward_type = self.group_config.combo_reward_type
         self.line_notes = self.group_config.line_notes
 
-        layout_buttons = QGridLayout(self)
+        layout_buttons = QGridLayout()
         layout_main.addLayout(layout_buttons)
 
         self._countdown = AutoAcceptCountdown(self)
@@ -96,7 +87,7 @@ class ExperimentPanel(QMainWindow):
         self.group_scene.load_config(self._config.value)
         self.group_animals.load_config(self._config.value)
 
-    def result(self) -> SessionConfig:
+    def _collect_result(self) -> SessionConfig:
         session_config = self.group_config.result()
         scene_result = self.group_scene.result()
         data = session_config.model_dump()
@@ -114,16 +105,14 @@ class ExperimentPanel(QMainWindow):
         return list(dict.fromkeys(name for name in names if name))
 
     def _on_save(self) -> None:
-        self._config.save(self.result())
+        self._config.save(self._collect_result())
 
     def _on_cancel(self) -> None:
-        self.close()
+        self.reject()
 
     def _on_continue(self) -> None:
         self._on_save()
-        self._accepted = True
-        self.close()
-        self.accepted.emit()
+        self.accept()
 
     def _start_auto_accept_countdown(self) -> None:
         panel_config = ConfigStore(get_mxbi_panel_config_path(), MXBIPanelConfig).value
@@ -133,8 +122,6 @@ class ExperimentPanel(QMainWindow):
         super().showEvent(event)
         self._start_auto_accept_countdown()
 
-    def closeEvent(self, event: QCloseEvent) -> None:
+    def done(self, result: int) -> None:
         self._countdown.stop()
-        super().closeEvent(event)
-        if event.isAccepted() and not self._accepted:
-            self.rejected.emit()
+        super().done(result)

--- a/src/mxbiflow/ui/mxbi_panel.py
+++ b/src/mxbiflow/ui/mxbi_panel.py
@@ -3,11 +3,11 @@ from typing import ClassVar
 from pymxbi import MXBIModel
 from pymxbi.detector import DetectorEnum, DetectorModel
 from pymxbi.rewarder import RewarderEnum, RewarderModel
-from PySide6.QtCore import Qt, Signal
-from PySide6.QtGui import QCloseEvent, QShowEvent
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QShowEvent
 from PySide6.QtWidgets import (
+    QDialog,
     QGridLayout,
-    QMainWindow,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -34,10 +34,7 @@ from .components.device_card import (
 from .components.devices import Devices
 
 
-class MXBIPanel(QMainWindow):
-    accepted = Signal()
-    rejected = Signal()
-
+class MXBIPanel(QDialog):
     _REWARDER_CARD_FACTORIES: ClassVar[dict[str, type[QWidget]]] = {
         RewarderEnum.RPI_GPIO: RPIGpioPumpCard,
         RewarderEnum.MOCK: MockRewarderCard,
@@ -51,7 +48,6 @@ class MXBIPanel(QMainWindow):
 
     def __init__(self) -> None:
         super().__init__()
-        self._accepted = False
         self._config = ConfigStore(get_mxbi_config_path(), MXBIModel)
         self._options = ConfigStore(get_options_session_path(), Options)
         self._panel_config = ConfigStore(get_mxbi_panel_config_path(), MXBIPanelConfig)
@@ -63,10 +59,7 @@ class MXBIPanel(QMainWindow):
     def _build_ui(self) -> None:
         self.setWindowTitle("MXBI Configuration Panel")
 
-        self._widget_main = QWidget()
-        self._layout_main = QVBoxLayout()
-        self._widget_main.setLayout(self._layout_main)
-        self.setCentralWidget(self._widget_main)
+        self._layout_main = QVBoxLayout(self)
 
         self.base_config = BaseConfig(self, self._options.value.mxbis)
         self._layout_main.addWidget(self.base_config)
@@ -137,9 +130,7 @@ class MXBIPanel(QMainWindow):
         self._collect_result()
         self._config.save()
         self._save_auto_accept_timeout()
-        self._accepted = True
-        self.close()
-        self.accepted.emit()
+        self.accept()
 
     def _save_auto_accept_timeout(self) -> None:
         self._panel_config.value.auto_accept_timeout_seconds = (
@@ -157,14 +148,12 @@ class MXBIPanel(QMainWindow):
         self._countdown.timeout.connect(self._on_continue)
 
     def _on_cancel(self) -> None:
-        self.close()
+        self.reject()
 
     def showEvent(self, event: QShowEvent) -> None:
         super().showEvent(event)
         self._start_auto_accept_countdown()
 
-    def closeEvent(self, event: QCloseEvent) -> None:
+    def done(self, result: int) -> None:
         self._countdown.stop()
-        super().closeEvent(event)
-        if event.isAccepted() and not self._accepted:
-            self.rejected.emit()
+        super().done(result)

--- a/src/mxbiflow/ui/wizard.py
+++ b/src/mxbiflow/ui/wizard.py
@@ -1,36 +1,15 @@
+from PySide6.QtWidgets import QDialog
+
 from ..scene import SceneManager
+from .application import require_application
 from .experiment_panel import ExperimentPanel
 from .mxbi_panel import MXBIPanel
 
 
-def config_wizard(scene_manager: SceneManager):
-    """
-    Launch the configuration wizard dialog for MXBI setup.
+def run_wizard(scene_manager: SceneManager) -> bool:
+    """Run the device and experiment configuration panels in sequence."""
+    _application = require_application()
 
-    Parameters
-    ----------
-    scene_manager : SceneManager
-        The scene manager instance providing stage and level information.
-
-    Notes
-    -----
-    This function creates a Qt application with a two-panel wizard:
-    MXBIPanel for MXBI configuration followed by ExperimentPanel for
-    experiment settings. The application exits when the wizard completes.
-    """
-    import sys
-
-    from PySide6.QtWidgets import QApplication
-
-    app = QApplication(sys.argv)
-
-    mxbi_panel = MXBIPanel()
-    experiment_panel = ExperimentPanel(scene_manager)
-    mxbi_panel.accepted.connect(experiment_panel.show)
-    mxbi_panel.rejected.connect(lambda: sys.exit(0))
-    experiment_panel.accepted.connect(app.quit)
-    experiment_panel.rejected.connect(lambda: sys.exit(0))
-
-    mxbi_panel.show()
-
-    app.exec()
+    if MXBIPanel().exec() != QDialog.DialogCode.Accepted:
+        return False
+    return ExperimentPanel(scene_manager).exec() == QDialog.DialogCode.Accepted

--- a/tests/test_backup_ui.py
+++ b/tests/test_backup_ui.py
@@ -23,7 +23,7 @@ from PySide6.QtWidgets import QApplication
 
 from mxbiflow.infra.backup import BackupTaskRunner
 from mxbiflow.ui.backup import (
-    _BackupProgressDialog,
+    BackupPanel,
     _task_progress_percent,
     run_backup,
 )
@@ -101,6 +101,22 @@ def completed_runner(
     return runner
 
 
+def panel_with_runner(
+    runner: BackupTaskRunner,
+    *,
+    success_auto_close_ms: int,
+) -> BackupPanel:
+    with (
+        patch("mxbiflow.ui.backup.BackupTaskRunner", return_value=runner),
+        patch.object(runner, "start"),
+    ):
+        return BackupPanel(
+            SOURCE,
+            DESTINATION,
+            success_auto_close_ms=success_auto_close_ms,
+        )
+
+
 class BackupUITests(unittest.TestCase):
     application: QApplication
 
@@ -143,7 +159,7 @@ class BackupUITests(unittest.TestCase):
         )
 
     def test_success_closes_automatically(self) -> None:
-        dialog = _BackupProgressDialog(
+        dialog = panel_with_runner(
             completed_runner(BackupStatus.SUCCEEDED),
             success_auto_close_ms=0,
         )
@@ -156,7 +172,7 @@ class BackupUITests(unittest.TestCase):
         self.assertEqual(dialog._progress_bar.value(), 100)
 
     def test_success_shows_auto_close_countdown(self) -> None:
-        dialog = _BackupProgressDialog(
+        dialog = panel_with_runner(
             completed_runner(BackupStatus.SUCCEEDED),
             success_auto_close_ms=5_000,
         )
@@ -171,7 +187,7 @@ class BackupUITests(unittest.TestCase):
         dialog.accept()
 
     def test_clicking_panel_stops_auto_close_countdown(self) -> None:
-        dialog = _BackupProgressDialog(
+        dialog = panel_with_runner(
             completed_runner(BackupStatus.SUCCEEDED),
             success_auto_close_ms=5_000,
         )
@@ -197,7 +213,7 @@ class BackupUITests(unittest.TestCase):
             BackupStatus.PARTIALLY_SUCCEEDED,
         ):
             with self.subTest(status=status):
-                dialog = _BackupProgressDialog(
+                dialog = panel_with_runner(
                     completed_runner(status, error="entry failed"),
                     success_auto_close_ms=0,
                 )
@@ -219,7 +235,7 @@ class BackupUITests(unittest.TestCase):
         with patch("mxbiflow.infra.backup.BackupClient", return_value=client):
             runner.start(SOURCE, DESTINATION)
 
-        dialog = _BackupProgressDialog(runner, success_auto_close_ms=0)
+        dialog = panel_with_runner(runner, success_auto_close_ms=0)
         dialog.show()
         self.application.processEvents()
         dialog.close()

--- a/tests/test_countdown_ui.py
+++ b/tests/test_countdown_ui.py
@@ -8,7 +8,7 @@ os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
 from PySide6.QtCore import Qt
 from PySide6.QtTest import QTest
-from PySide6.QtWidgets import QApplication, QLabel, QPushButton, QSpinBox
+from PySide6.QtWidgets import QApplication, QDialog, QLabel, QPushButton, QSpinBox
 
 from mxbiflow.core.path import get_mxbi_panel_config_path, set_base_path
 from mxbiflow.models.panel import MXBIPanelConfig
@@ -121,7 +121,7 @@ class PanelCountdownTests(unittest.TestCase):
         panel.show()
         self.application.processEvents()
 
-        QTest.mouseClick(panel.centralWidget(), Qt.MouseButton.LeftButton)
+        QTest.mouseClick(panel, Qt.MouseButton.LeftButton)
         self.assertTrue(countdown.is_active())
 
         QTest.mouseClick(panel.save_button, Qt.MouseButton.LeftButton)
@@ -130,6 +130,42 @@ class PanelCountdownTests(unittest.TestCase):
         QTest.mouseClick(countdown.stop_button, Qt.MouseButton.LeftButton)
         self.assertFalse(countdown.is_active())
         panel.close()
+
+    def test_panel_actions_use_dialog_result_codes(self) -> None:
+        mxbi_panel = MXBIPanel()
+        mxbi_panel.show()
+        self.application.processEvents()
+        QTest.mouseClick(mxbi_panel.cancel_button, Qt.MouseButton.LeftButton)
+        self.assertEqual(mxbi_panel.result(), QDialog.DialogCode.Rejected)
+
+        mxbi_panel = MXBIPanel()
+        mxbi_panel.show()
+        self.application.processEvents()
+        QTest.mouseClick(mxbi_panel.continue_button, Qt.MouseButton.LeftButton)
+        self.assertEqual(mxbi_panel.result(), QDialog.DialogCode.Accepted)
+
+        experiment_panel = ExperimentPanel(SceneManager())
+        cancel_button = next(
+            button
+            for button in experiment_panel.findChildren(QPushButton)
+            if button.text() == "Cancel"
+        )
+        experiment_panel.show()
+        self.application.processEvents()
+        QTest.mouseClick(cancel_button, Qt.MouseButton.LeftButton)
+        self.assertEqual(experiment_panel.result(), QDialog.DialogCode.Rejected)
+
+    def test_escape_rejects_panel_and_stops_countdown(self) -> None:
+        panel = MXBIPanel()
+        countdown = find_countdown(panel)
+        panel.show()
+        self.application.processEvents()
+
+        QTest.keyClick(panel, Qt.Key.Key_Escape)
+        self.application.processEvents()
+
+        self.assertEqual(panel.result(), QDialog.DialogCode.Rejected)
+        self.assertFalse(countdown.is_active())
 
     def test_only_mxbi_panel_configures_latest_timeout(self) -> None:
         mxbi_panel = MXBIPanel()

--- a/tests/test_wizard_ui.py
+++ b/tests/test_wizard_ui.py
@@ -1,0 +1,113 @@
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication, QDialog
+
+from mxbiflow.ui.application import require_application
+from mxbiflow.ui.wizard import run_wizard
+
+
+class ApplicationTests(unittest.TestCase):
+    application: QApplication
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        application = QApplication.instance()
+        cls.application = (
+            application if isinstance(application, QApplication) else QApplication([])
+        )
+
+    def test_existing_application_is_reused_and_kept_running(self) -> None:
+        self.application.setQuitOnLastWindowClosed(True)
+
+        result = require_application()
+
+        self.assertIs(result, self.application)
+        self.assertFalse(result.quitOnLastWindowClosed())
+
+
+class WizardTests(unittest.TestCase):
+    @patch("mxbiflow.ui.wizard.ExperimentPanel")
+    @patch("mxbiflow.ui.wizard.MXBIPanel")
+    @patch("mxbiflow.ui.wizard.require_application")
+    def test_first_panel_rejection_stops_the_wizard(
+        self,
+        require_application: Mock,
+        mxbi_panel_class: Mock,
+        experiment_panel_class: Mock,
+    ) -> None:
+        mxbi_panel_class.return_value.exec.return_value = QDialog.DialogCode.Rejected
+
+        self.assertFalse(run_wizard(Mock()))
+
+        require_application.assert_called_once_with()
+        experiment_panel_class.assert_not_called()
+
+    @patch("mxbiflow.ui.wizard.ExperimentPanel")
+    @patch("mxbiflow.ui.wizard.MXBIPanel")
+    @patch("mxbiflow.ui.wizard.require_application")
+    def test_second_panel_rejection_returns_false(
+        self,
+        _require_application: Mock,
+        mxbi_panel_class: Mock,
+        experiment_panel_class: Mock,
+    ) -> None:
+        mxbi_panel_class.return_value.exec.return_value = QDialog.DialogCode.Accepted
+        experiment_panel_class.return_value.exec.return_value = (
+            QDialog.DialogCode.Rejected
+        )
+
+        self.assertFalse(run_wizard(Mock()))
+
+    @patch("mxbiflow.ui.wizard.ExperimentPanel")
+    @patch("mxbiflow.ui.wizard.MXBIPanel")
+    @patch("mxbiflow.ui.wizard.require_application")
+    def test_accepted_panels_run_in_order(
+        self,
+        _require_application: Mock,
+        mxbi_panel_class: Mock,
+        experiment_panel_class: Mock,
+    ) -> None:
+        events: list[str] = []
+        mxbi_panel_class.return_value.exec.side_effect = lambda: (
+            events.append("mxbi") or QDialog.DialogCode.Accepted
+        )
+        experiment_panel_class.return_value.exec.side_effect = lambda: (
+            events.append("experiment") or QDialog.DialogCode.Accepted
+        )
+
+        self.assertTrue(run_wizard(Mock()))
+        self.assertEqual(events, ["mxbi", "experiment"])
+
+    def test_application_is_created_and_kept_available(self) -> None:
+        code = """
+import os
+import gc
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+from PySide6.QtWidgets import QApplication
+from mxbiflow.ui.application import require_application
+
+application = require_application()
+assert QApplication.instance() is application
+assert not application.quitOnLastWindowClosed()
+del application
+gc.collect()
+assert isinstance(QApplication.instance(), QApplication)
+"""
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- convert the configuration panels from `QMainWindow` to standard `QDialog` result handling
- add reusable `run_wizard()` and public `BackupPanel` APIs
- centralize `QApplication` lifecycle management and update startup documentation
- expand UI tests for accept, reject, countdown, backup, and sequential flow behavior

## Why

The previous wizard coordinated windows through custom signals and a top-level application event loop. The new flow makes the startup sequence explicit and reusable across applications while preserving cancellation behavior.

## Validation

- `uv run python -m unittest discover -s tests -v` (54 tests)
- Ruff checks on changed files
- Pyright (0 errors)
- `git diff --check`
