### PR TITLE
fix(ui): make countdown controls explicit

### DIFF
--- a/src/mxbiflow/ui/backup.py
+++ b/src/mxbiflow/ui/backup.py
@@ -4,7 +4,7 @@ from pymotego import (
     BackupStatus,
     BackupTask,
 )
-from PySide6.QtCore import QEvent, QObject, Qt, QTimer
+from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import (
     QDialog,
@@ -13,7 +13,6 @@ from PySide6.QtWidgets import (
     QProgressBar,
     QPushButton,
     QVBoxLayout,
-    QWidget,
 )
 
 from ..infra.backup import BackupTaskRunner
@@ -67,9 +66,6 @@ class BackupPanel(QDialog):
         self._remaining_seconds = 0
 
         self._build_ui()
-        self.installEventFilter(self)
-        for widget in self.findChildren(QWidget):
-            widget.installEventFilter(self)
 
         self._refresh_timer = QTimer(self)
         self._refresh_timer.setInterval(refresh_interval_ms)
@@ -132,9 +128,13 @@ class BackupPanel(QDialog):
 
         buttons = QHBoxLayout()
         buttons.addStretch()
+        self._stop_countdown_button = QPushButton("Stop countdown", self)
+        self._stop_countdown_button.setEnabled(False)
+        self._stop_countdown_button.clicked.connect(self._stop_auto_close)
+        buttons.addWidget(self._stop_countdown_button)
         self._close_button = QPushButton("Close", self)
+        self._close_button.setEnabled(False)
         self._close_button.clicked.connect(self.accept)
-        self._close_button.hide()
         buttons.addWidget(self._close_button)
         layout.addLayout(buttons)
 
@@ -202,6 +202,8 @@ class BackupPanel(QDialog):
         self._progress_bar.setRange(0, 100)
         self._progress_bar.setValue(100)
         self._status_label.setText("Backup succeeded.")
+        self._stop_countdown_button.setEnabled(True)
+        self._close_button.setEnabled(True)
         if self._success_auto_close_ms > 0:
             self._start_countdown()
         self._auto_close_timer.start(self._success_auto_close_ms)
@@ -234,14 +236,8 @@ class BackupPanel(QDialog):
             return
         self._countdown_timer.stop()
         self._auto_close_timer.stop()
-        self._countdown_label.setText("Auto-close cancelled")
-        self._close_button.show()
+        self._stop_countdown_button.setEnabled(False)
         self._close_button.setFocus()
-
-    def eventFilter(self, obj: QObject, event: QEvent) -> bool:
-        if event.type() == QEvent.Type.MouseButtonPress:
-            self._stop_auto_close()
-        return super().eventFilter(obj, event)
 
     def _show_failure(self, message: str) -> None:
         self._terminal_state_shown = True
@@ -251,7 +247,7 @@ class BackupPanel(QDialog):
         self._status_label.setText("Backup requires attention")
         self._error_label.setText(message)
         self._error_label.show()
-        self._close_button.show()
+        self._close_button.setEnabled(True)
         self._close_button.setFocus()
 
     def closeEvent(self, event: QCloseEvent) -> None:

--- a/src/mxbiflow/ui/components/countdown.py
+++ b/src/mxbiflow/ui/components/countdown.py
@@ -35,6 +35,7 @@ class AutoAcceptCountdown(QWidget):
 
         self._remaining_seconds = seconds
         self._is_active = True
+        self.stop_button.setEnabled(True)
         self._update_label()
         self.show()
         self._timer.start()
@@ -42,8 +43,7 @@ class AutoAcceptCountdown(QWidget):
     def stop(self) -> None:
         self._timer.stop()
         self._is_active = False
-        self._remaining_seconds = 0
-        self.hide()
+        self.stop_button.setEnabled(False)
 
     def is_active(self) -> bool:
         return self._is_active

--- a/tests/test_backup_ui.py
+++ b/tests/test_backup_ui.py
@@ -181,12 +181,14 @@ class BackupUITests(unittest.TestCase):
 
         self.assertTrue(dialog._countdown_label.isVisible())
         self.assertEqual(dialog._countdown_label.text(), "Auto-closing in 5s")
+        self.assertTrue(dialog._stop_countdown_button.isEnabled())
+        self.assertTrue(dialog._close_button.isEnabled())
 
         dialog._tick_countdown()
         self.assertEqual(dialog._countdown_label.text(), "Auto-closing in 4s")
         dialog.accept()
 
-    def test_clicking_panel_stops_auto_close_countdown(self) -> None:
+    def test_only_stop_button_stops_auto_close_countdown(self) -> None:
         dialog = panel_with_runner(
             completed_runner(BackupStatus.SUCCEEDED),
             success_auto_close_ms=5_000,
@@ -197,10 +199,21 @@ class BackupUITests(unittest.TestCase):
         QTest.mouseClick(dialog, Qt.MouseButton.LeftButton)
         self.application.processEvents()
 
+        self.assertTrue(dialog._countdown_timer.isActive())
+        self.assertTrue(dialog._auto_close_timer.isActive())
+
+        countdown_text = dialog._countdown_label.text()
+        QTest.mouseClick(
+            dialog._stop_countdown_button,
+            Qt.MouseButton.LeftButton,
+        )
+        self.application.processEvents()
+
         self.assertFalse(dialog._countdown_timer.isActive())
         self.assertFalse(dialog._auto_close_timer.isActive())
-        self.assertEqual(dialog._countdown_label.text(), "Auto-close cancelled")
-        self.assertTrue(dialog._close_button.isVisible())
+        self.assertEqual(dialog._countdown_label.text(), countdown_text)
+        self.assertFalse(dialog._stop_countdown_button.isEnabled())
+        self.assertTrue(dialog._close_button.isEnabled())
 
         self.application.processEvents()
         self.application.processEvents()
@@ -215,13 +228,16 @@ class BackupUITests(unittest.TestCase):
             with self.subTest(status=status):
                 dialog = panel_with_runner(
                     completed_runner(status, error="entry failed"),
-                    success_auto_close_ms=0,
+                    success_auto_close_ms=5_000,
                 )
                 dialog.show()
                 self.application.processEvents()
 
                 self.assertTrue(dialog.isVisible())
-                self.assertTrue(dialog._close_button.isVisible())
+                self.assertFalse(dialog._countdown_timer.isActive())
+                self.assertFalse(dialog._auto_close_timer.isActive())
+                self.assertFalse(dialog._stop_countdown_button.isEnabled())
+                self.assertTrue(dialog._close_button.isEnabled())
                 self.assertIn("entry failed", dialog._error_label.text())
                 dialog.accept()
 
@@ -238,6 +254,10 @@ class BackupUITests(unittest.TestCase):
         dialog = panel_with_runner(runner, success_auto_close_ms=0)
         dialog.show()
         self.application.processEvents()
+        self.assertTrue(dialog._stop_countdown_button.isVisible())
+        self.assertFalse(dialog._stop_countdown_button.isEnabled())
+        self.assertTrue(dialog._close_button.isVisible())
+        self.assertFalse(dialog._close_button.isEnabled())
         dialog.close()
         self.application.processEvents()
 

--- a/tests/test_countdown_ui.py
+++ b/tests/test_countdown_ui.py
@@ -43,13 +43,24 @@ class AutoAcceptCountdownTests(unittest.TestCase):
     def test_only_stop_button_stops_countdown(self) -> None:
         countdown = AutoAcceptCountdown()
         countdown.start(10)
+        label = countdown.findChild(QLabel)
+        self.assertIsNotNone(label)
+        if label is None:
+            raise AssertionError("Remaining-time label not found in countdown widget")
 
         QTest.mouseClick(countdown, Qt.MouseButton.LeftButton)
         self.assertTrue(countdown.is_active())
 
         QTest.mouseClick(countdown.stop_button, Qt.MouseButton.LeftButton)
         self.assertFalse(countdown.is_active())
-        self.assertTrue(countdown.isHidden())
+        self.assertFalse(countdown.isHidden())
+        self.assertEqual(label.text(), "Auto: 10s")
+        self.assertFalse(countdown.stop_button.isEnabled())
+
+        countdown.start(5)
+        self.assertTrue(countdown.is_active())
+        self.assertEqual(label.text(), "Auto: 5s")
+        self.assertTrue(countdown.stop_button.isEnabled())
 
     def test_countdowns_are_independent_and_emit_once(self) -> None:
         first = TestCountdown()
@@ -129,6 +140,7 @@ class PanelCountdownTests(unittest.TestCase):
 
         QTest.mouseClick(countdown.stop_button, Qt.MouseButton.LeftButton)
         self.assertFalse(countdown.is_active())
+        self.assertTrue(countdown.isVisible())
         panel.close()
 
     def test_panel_actions_use_dialog_result_codes(self) -> None:


### PR DESCRIPTION
## Summary
- replace click-anywhere backup countdown cancellation with an explicit button
- enable automatic closing only after successful backups
- keep countdown widgets visible with frozen values after manual stops

## Validation
- `env QT_QPA_PLATFORM=offscreen uv run python -m unittest discover -s tests -v` (54 passed)
- `uv run ruff check src/mxbiflow/ui/backup.py src/mxbiflow/ui/components/countdown.py tests/test_backup_ui.py tests/test_countdown_ui.py`
- `uv run pyright`
- `git diff --check`