### PR TITLE
feat(ui): add session summary panel

### DIFF
--- a/src/mxbiflow/infra/post_processing.py
+++ b/src/mxbiflow/infra/post_processing.py
@@ -31,8 +31,10 @@ class SessionSummary(BaseModel):
     start_at: datetime | None
     end_at: datetime | None
     duration_seconds: float
+    experimenter: str = ""
     reward_type: str
     total_animals: int
+    note: str = ""
     animals: list[AnimalSummary]
 
 
@@ -114,8 +116,10 @@ def summarize() -> SessionSummary:
         start_at=session.start_at,
         end_at=session.end_at,
         duration_seconds=duration,
+        experimenter=session.experimenter,
         reward_type=session.reward_type.value,
         total_animals=len(session.animals),
+        note=session.note,
         animals=animal_summaries,
     )
 

--- a/src/mxbiflow/ui/__init__.py
+++ b/src/mxbiflow/ui/__init__.py
@@ -1,12 +1,15 @@
 from .backup import BackupPanel, run_backup
 from .experiment_panel import ExperimentPanel
 from .mxbi_panel import MXBIPanel
+from .session_summary_panel import SessionSummaryPanel, run_session_summary
 from .wizard import run_wizard
 
 __all__ = [
     "BackupPanel",
     "ExperimentPanel",
     "MXBIPanel",
+    "SessionSummaryPanel",
     "run_backup",
+    "run_session_summary",
     "run_wizard",
 ]

--- a/src/mxbiflow/ui/session_summary_panel.py
+++ b/src/mxbiflow/ui/session_summary_panel.py
@@ -1,0 +1,203 @@
+from datetime import datetime
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QShowEvent
+from PySide6.QtWidgets import (
+    QAbstractItemView,
+    QDialog,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QPushButton,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from ..infra.post_processing import SessionSummary, summarize
+from .application import require_application
+from .components.countdown import AutoAcceptCountdown
+
+_AUTO_ACCEPT_SECONDS = 30
+_VISIBLE_TABLE_ROWS = 2
+
+
+def run_session_summary() -> bool:
+    """Show the current session summary and return whether upload should continue."""
+    _application = require_application()
+    return SessionSummaryPanel(summarize()).exec() == QDialog.DialogCode.Accepted
+
+
+class SessionSummaryPanel(QDialog):
+    def __init__(self, summary: SessionSummary) -> None:
+        super().__init__()
+        self._summary = summary
+
+        self.setWindowTitle("Session Summary")
+        self.setModal(True)
+        self.setMinimumSize(760, 480)
+        self.resize(900, 520)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(8)
+        layout.addWidget(self._build_session_group())
+        layout.addWidget(self._build_animals_group())
+        layout.addWidget(self._build_stages_group())
+        layout.addLayout(self._build_buttons())
+
+    def _build_session_group(self) -> QGroupBox:
+        group = QGroupBox("Session", self)
+        grid = QGridLayout(group)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(4)
+        grid.setColumnStretch(1, 1)
+        grid.setColumnStretch(3, 1)
+
+        rows = (
+            (
+                ("Session ID", str(self._summary.session_id)),
+                ("Start Time", _format_timestamp(self._summary.start_at)),
+            ),
+            (
+                ("End Time", _format_timestamp(self._summary.end_at)),
+                ("Duration", _format_duration(self._summary.duration_seconds)),
+            ),
+            (
+                ("Experimenter", self._summary.experimenter or "N/A"),
+                ("Reward Type", self._summary.reward_type or "N/A"),
+            ),
+            (
+                ("Total Animals", str(self._summary.total_animals)),
+                ("Note", self._summary.note or "N/A"),
+            ),
+        )
+        for row_index, row in enumerate(rows):
+            for pair_index, (label_text, value) in enumerate(row):
+                column = pair_index * 2
+                grid.addWidget(QLabel(label_text, group), row_index, column)
+                value_label = QLabel(value, group)
+                value_label.setTextInteractionFlags(
+                    Qt.TextInteractionFlag.TextSelectableByMouse
+                )
+                value_label.setWordWrap(label_text == "Note")
+                grid.addWidget(value_label, row_index, column + 1)
+
+        return group
+
+    def _build_animals_group(self) -> QGroupBox:
+        group = QGroupBox("Animals", self)
+        layout = QVBoxLayout(group)
+        headers = (
+            "Name",
+            "RFID ID",
+            "Total Trials",
+            "Animal Sessions",
+            "Duration",
+        )
+        rows = [
+            (
+                animal.name,
+                animal.rfid_id or "N/A",
+                str(animal.total_trials),
+                str(animal.animal_sessions),
+                _format_duration(animal.total_duration_seconds),
+            )
+            for animal in self._summary.animals
+        ]
+        self.animals_table = _build_read_only_table(headers, rows, group)
+        self.animals_table.setAccessibleName("Animal session summary")
+        layout.addWidget(self.animals_table)
+        return group
+
+    def _build_stages_group(self) -> QGroupBox:
+        group = QGroupBox("Stages", self)
+        layout = QVBoxLayout(group)
+        headers = ("Animal", "Stage", "Trials", "Initial Level", "Final Level")
+        rows = [
+            (
+                animal.name,
+                stage.name,
+                str(stage.trials),
+                str(stage.initial_level),
+                str(stage.final_level),
+            )
+            for animal in self._summary.animals
+            for stage in animal.stages
+        ]
+        self.stages_table = _build_read_only_table(headers, rows, group)
+        self.stages_table.setAccessibleName("Stage session summary")
+        layout.addWidget(self.stages_table)
+        return group
+
+    def _build_buttons(self) -> QHBoxLayout:
+        layout = QHBoxLayout()
+        self._countdown = AutoAcceptCountdown(self)
+        self._countdown.timeout.connect(self.accept)
+        layout.addWidget(self._countdown)
+        layout.addStretch()
+
+        cancel_button = QPushButton("Cancel", self)
+        cancel_button.clicked.connect(self.reject)
+        layout.addWidget(cancel_button)
+
+        upload_button = QPushButton("Upload", self)
+        upload_button.clicked.connect(self.accept)
+        layout.addWidget(upload_button)
+        return layout
+
+    def showEvent(self, event: QShowEvent) -> None:
+        super().showEvent(event)
+        self._countdown.start(_AUTO_ACCEPT_SECONDS)
+
+    def done(self, result: int) -> None:
+        self._countdown.stop()
+        super().done(result)
+
+
+def _build_read_only_table(
+    headers: tuple[str, ...],
+    rows: list[tuple[str, ...]],
+    parent: QGroupBox,
+) -> QTableWidget:
+    table = QTableWidget(len(rows), len(headers), parent)
+    table.setHorizontalHeaderLabels(headers)
+    table.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)
+    table.setSelectionBehavior(QAbstractItemView.SelectionBehavior.SelectRows)
+    table.setAlternatingRowColors(True)
+    table.verticalHeader().setVisible(False)
+    table.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+
+    for row_index, row in enumerate(rows):
+        for column_index, value in enumerate(row):
+            table.setItem(row_index, column_index, QTableWidgetItem(value))
+
+    visible_rows = min(max(len(rows), 1), _VISIBLE_TABLE_ROWS)
+    table_height = (
+        table.horizontalHeader().sizeHint().height()
+        + visible_rows * table.verticalHeader().defaultSectionSize()
+        + table.frameWidth() * 2
+    )
+    table.setFixedHeight(table_height)
+
+    return table
+
+
+def _format_timestamp(value: datetime | None) -> str:
+    if value is None:
+        return "N/A"
+    return value.astimezone().strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _format_duration(seconds: float) -> str:
+    if seconds <= 0:
+        return "N/A"
+    hours, remainder = divmod(int(seconds), 3600)
+    minutes, secs = divmod(remainder, 60)
+    if hours > 0:
+        return f"{hours}h {minutes}m {secs}s"
+    if minutes > 0:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -1,0 +1,33 @@
+import unittest
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+from mxbiflow.infra.post_processing import summarize
+
+
+class SummarizeTests(unittest.TestCase):
+    @patch("mxbiflow.infra.post_processing.get_mxbiflow")
+    def test_session_metadata_is_included(self, get_mxbiflow: Mock) -> None:
+        start_at = datetime(2026, 8, 3, 9, 0, tzinfo=UTC)
+        end_at = datetime(2026, 8, 3, 9, 2, tzinfo=UTC)
+        session = get_mxbiflow.return_value.session
+        session.session_id = 3
+        session.start_at = start_at
+        session.end_at = end_at
+        session.experimenter = "Alice"
+        session.reward_type.value = "agum_one_fifth"
+        session.note = "Calibration complete"
+        session.animals = {}
+
+        summary = summarize()
+
+        self.assertEqual(summary.session_id, 3)
+        self.assertEqual(summary.duration_seconds, 120)
+        self.assertEqual(summary.experimenter, "Alice")
+        self.assertEqual(summary.reward_type, "agum_one_fifth")
+        self.assertEqual(summary.note, "Calibration complete")
+        self.assertEqual(summary.total_animals, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_summary_ui.py
+++ b/tests/test_session_summary_ui.py
@@ -1,0 +1,219 @@
+import os
+import unittest
+from datetime import UTC, datetime
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QLabel, QPushButton, QTableWidget
+
+from mxbiflow.infra.post_processing import (
+    AnimalSummary,
+    SessionSummary,
+    StageSummary,
+)
+from mxbiflow.ui.components.countdown import AutoAcceptCountdown
+from mxbiflow.ui.session_summary_panel import (
+    SessionSummaryPanel,
+    run_session_summary,
+)
+
+
+def make_summary(*, with_animals: bool = True) -> SessionSummary:
+    animals = (
+        [
+            AnimalSummary(
+                name="mouse-1",
+                rfid_id="rfid-1",
+                total_trials=12,
+                animal_sessions=2,
+                total_duration_seconds=125,
+                stages=[
+                    StageSummary(
+                        name="discrimination",
+                        trials=12,
+                        initial_level=1,
+                        final_level=3,
+                    )
+                ],
+            )
+        ]
+        if with_animals
+        else []
+    )
+    return SessionSummary(
+        session_id=7,
+        start_at=datetime(2026, 8, 3, 9, 0, tzinfo=UTC),
+        end_at=datetime(2026, 8, 3, 10, 1, 2, tzinfo=UTC),
+        duration_seconds=3662,
+        experimenter="Alice",
+        reward_type="agum_one_fifth",
+        total_animals=len(animals),
+        note="Daily calibration complete",
+        animals=animals,
+    )
+
+
+class SessionSummaryPanelTests(unittest.TestCase):
+    application: QApplication
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        application = QApplication.instance()
+        cls.application = (
+            application if isinstance(application, QApplication) else QApplication([])
+        )
+
+    def test_summary_fields_and_tables_are_displayed(self) -> None:
+        panel = SessionSummaryPanel(make_summary())
+
+        labels = {label.text() for label in panel.findChildren(QLabel)}
+        self.assertTrue(
+            {
+                "7",
+                "1h 1m 2s",
+                "Alice",
+                "agum_one_fifth",
+                "Daily calibration complete",
+            }.issubset(labels)
+        )
+
+        tables = {
+            table.accessibleName(): table for table in panel.findChildren(QTableWidget)
+        }
+        animals_table = tables["Animal session summary"]
+        stages_table = tables["Stage session summary"]
+        self.assertEqual(animals_table.rowCount(), 1)
+        animal_name = animals_table.item(0, 0)
+        animal_duration = animals_table.item(0, 4)
+        assert animal_name is not None
+        assert animal_duration is not None
+        self.assertEqual(animal_name.text(), "mouse-1")
+        self.assertEqual(animal_duration.text(), "2m 5s")
+        self.assertEqual(stages_table.rowCount(), 1)
+        stage_name = stages_table.item(0, 1)
+        final_level = stages_table.item(0, 4)
+        assert stage_name is not None
+        assert final_level is not None
+        self.assertEqual(stage_name.text(), "discrimination")
+        self.assertEqual(final_level.text(), "3")
+        self.assertFalse(
+            bool(animals_table.editTriggers() & QTableWidget.EditTrigger.DoubleClicked)
+        )
+
+    def test_empty_animal_and_stage_tables_are_supported(self) -> None:
+        panel = SessionSummaryPanel(make_summary(with_animals=False))
+        tables = panel.findChildren(QTableWidget)
+
+        self.assertEqual(len(tables), 2)
+        self.assertTrue(all(table.rowCount() == 0 for table in tables))
+
+    def test_upload_accepts_and_cancel_rejects(self) -> None:
+        panel = SessionSummaryPanel(make_summary())
+        buttons = {button.text(): button for button in panel.findChildren(QPushButton)}
+        self.assertEqual(buttons["Cancel"].minimumHeight(), 0)
+        self.assertEqual(buttons["Upload"].minimumHeight(), 0)
+        self.assertFalse(buttons["Upload"].isDefault())
+
+        QTest.mouseClick(buttons["Upload"], Qt.MouseButton.LeftButton)
+        self.assertEqual(panel.result(), SessionSummaryPanel.DialogCode.Accepted)
+
+        panel = SessionSummaryPanel(make_summary())
+        buttons = {button.text(): button for button in panel.findChildren(QPushButton)}
+        QTest.mouseClick(buttons["Cancel"], Qt.MouseButton.LeftButton)
+        self.assertEqual(panel.result(), SessionSummaryPanel.DialogCode.Rejected)
+
+    def test_countdown_starts_at_30_seconds_and_accepts_on_timeout(self) -> None:
+        panel = SessionSummaryPanel(make_summary())
+        countdown = panel.findChild(AutoAcceptCountdown)
+        assert countdown is not None
+
+        panel.show()
+        self.application.processEvents()
+        countdown_label = countdown.findChild(QLabel)
+        assert countdown_label is not None
+        self.assertEqual(countdown_label.text(), "Auto: 30s")
+        self.assertTrue(countdown.is_active())
+
+        countdown.timeout.emit()
+
+        self.assertEqual(panel.result(), SessionSummaryPanel.DialogCode.Accepted)
+        self.assertFalse(countdown.is_active())
+
+    def test_stopped_countdown_keeps_manual_actions_available(self) -> None:
+        panel = SessionSummaryPanel(make_summary())
+        countdown = panel.findChild(AutoAcceptCountdown)
+        assert countdown is not None
+        panel.show()
+        self.application.processEvents()
+
+        QTest.mouseClick(countdown.stop_button, Qt.MouseButton.LeftButton)
+
+        self.assertFalse(countdown.is_active())
+        self.assertEqual(panel.result(), SessionSummaryPanel.DialogCode.Rejected)
+        upload_button = next(
+            button
+            for button in panel.findChildren(QPushButton)
+            if button.text() == "Upload"
+        )
+        QTest.mouseClick(upload_button, Qt.MouseButton.LeftButton)
+        self.assertEqual(panel.result(), SessionSummaryPanel.DialogCode.Accepted)
+
+    def test_tables_show_two_rows_and_scroll_when_data_overflows(self) -> None:
+        summary = make_summary()
+        animal = summary.animals[0]
+        summary.animals = [
+            animal.model_copy(
+                update={
+                    "name": f"mouse-{index}",
+                    "stages": [
+                        animal.stages[0].model_copy(update={"name": f"stage-{index}"})
+                    ],
+                }
+            )
+            for index in range(4)
+        ]
+        summary.total_animals = len(summary.animals)
+        panel = SessionSummaryPanel(summary)
+        panel.show()
+        self.application.processEvents()
+
+        tables = panel.findChildren(QTableWidget)
+        self.assertEqual(len(tables), 2)
+        for table in tables:
+            two_rows_height = (
+                table.horizontalHeader().sizeHint().height()
+                + 2 * table.verticalHeader().defaultSectionSize()
+                + table.frameWidth() * 2
+            )
+            self.assertEqual(table.height(), two_rows_height)
+            self.assertGreater(table.verticalScrollBar().maximum(), 0)
+
+        panel.close()
+
+    @patch("mxbiflow.ui.session_summary_panel.SessionSummaryPanel")
+    @patch("mxbiflow.ui.session_summary_panel.summarize")
+    @patch("mxbiflow.ui.session_summary_panel.require_application")
+    def test_run_session_summary_returns_dialog_decision(
+        self,
+        require_application: Mock,
+        summarize: Mock,
+        panel_class: Mock,
+    ) -> None:
+        panel_class.return_value.exec.side_effect = [
+            SessionSummaryPanel.DialogCode.Accepted,
+            SessionSummaryPanel.DialogCode.Rejected,
+        ]
+
+        self.assertTrue(run_session_summary())
+        self.assertFalse(run_session_summary())
+
+        self.assertEqual(require_application.call_count, 2)
+        self.assertEqual(summarize.call_count, 2)
+        self.assertEqual(panel_class.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a compact post-session summary dialog for session, animal, and stage data
- auto-continue to upload after 30 seconds with stop, cancel, and upload controls
- expose `run_session_summary()` and extend session summary metadata

## Impact

Operators can review session results before upload without expanding the application entrypoint with UI construction details.

## Validation

- `env QT_QPA_PLATFORM=offscreen uv run python -m unittest discover -s tests` (62 tests)
- `uv run pyright`
- targeted Ruff and format checks
- `git diff --check`