### PR TITLE
refactor(ui): derive mxbi id from hostname

### DIFF
--- a/config/options.json
+++ b/config/options.json
@@ -1,16 +1,4 @@
 {
-    "mxbis": [
-        "debug",
-        "mxbi1",
-        "mxbi2",
-        "mxbi3",
-        "mxbi4",
-        "mxbi5",
-        "mxbi6",
-        "mxbi7",
-        "mxbi8",
-        "mxbi9"
-    ],
     "experimenter": [
         "jgr",
         "jcm",

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -464,6 +464,5 @@ class Session(BaseModel):
 
 
 class Options(BaseModel):
-    mxbis: list[str] = Field(default_factory=list, frozen=True)
     experimenter: list[str] = Field(default_factory=list, frozen=True)
     animals: dict[str, str] = Field(default_factory=dict, frozen=True)

--- a/src/mxbiflow/ui/components/baseconfig.py
+++ b/src/mxbiflow/ui/components/baseconfig.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import socket
+
 from pymxbi import MXBIModel
 from pymxbi.screen import get_screen_size
 from PySide6.QtWidgets import (
@@ -13,7 +15,7 @@ from PySide6.QtWidgets import (
 
 
 class BaseConfig(QGroupBox):
-    def __init__(self, parent: QWidget | None, mxbi_options: list[str]) -> None:
+    def __init__(self, parent: QWidget | None) -> None:
         super().__init__(parent)
 
         self.setTitle("Base config")
@@ -22,9 +24,8 @@ class BaseConfig(QGroupBox):
         self.setLayout(self._layout)
 
         self._label_mxbi = QLabel("mxbi id:")
-        self._combo_mxbi = QComboBox()
-        self._combo_mxbi.addItems(mxbi_options)
-        self._layout.addRow(self._label_mxbi, self._combo_mxbi)
+        self._value_mxbi = QLabel(self.mxbi_id)
+        self._layout.addRow(self._label_mxbi, self._value_mxbi)
 
         self._label_screen = QLabel("screen:")
         self._combo_screen = QComboBox()
@@ -43,7 +44,7 @@ class BaseConfig(QGroupBox):
 
     @property
     def mxbi_id(self) -> str:
-        return self._combo_mxbi.currentText()
+        return socket.gethostname()
 
     @property
     def screen_size(self) -> tuple[int, int]:
@@ -54,7 +55,6 @@ class BaseConfig(QGroupBox):
         return self._spin_auto_accept.value()
 
     def load_from_model(self, model: MXBIModel) -> None:
-        self._combo_mxbi.setCurrentText(model.mxbi_id)
         for i in range(self._combo_screen.count()):
             if self._combo_screen.itemData(i) == tuple(model.screen_size):
                 self._combo_screen.setCurrentIndex(i)

--- a/src/mxbiflow/ui/mxbi_panel.py
+++ b/src/mxbiflow/ui/mxbi_panel.py
@@ -61,7 +61,7 @@ class MXBIPanel(QDialog):
 
         self._layout_main = QVBoxLayout(self)
 
-        self.base_config = BaseConfig(self, self._options.value.mxbis)
+        self.base_config = BaseConfig(self)
         self._layout_main.addWidget(self.base_config)
         self._build_device_groups()
         self._layout_main.addLayout(self._build_buttons_layout())

--- a/tests/test_baseconfig_ui.py
+++ b/tests/test_baseconfig_ui.py
@@ -1,0 +1,75 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from pymxbi import MXBIModel
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QLabel
+
+from mxbiflow.core.path import get_mxbi_config_path, set_base_path
+from mxbiflow.models.session import Options
+from mxbiflow.ui.mxbi_panel import MXBIPanel
+
+
+class BaseConfigTests(unittest.TestCase):
+    application: QApplication
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        application = QApplication.instance()
+        cls.application = (
+            application if isinstance(application, QApplication) else QApplication([])
+        )
+
+    def setUp(self) -> None:
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        set_base_path(Path(self._temporary_directory.name))
+
+    def tearDown(self) -> None:
+        self.application.processEvents()
+        self._temporary_directory.cleanup()
+
+    @patch("mxbiflow.ui.components.baseconfig.socket.gethostname")
+    def test_hostname_is_read_only_and_saved_as_mxbi_id(
+        self, gethostname: Mock
+    ) -> None:
+        gethostname.return_value = "mxbi-host"
+        config_path = get_mxbi_config_path()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            MXBIModel(mxbi_id="outdated").model_dump_json(indent=4),
+            encoding="utf-8",
+        )
+
+        panel = MXBIPanel()
+        labels = [label.text() for label in panel.findChildren(QLabel)]
+        self.assertIn("mxbi-host", labels)
+
+        QTest.mouseClick(panel.save_button, Qt.MouseButton.LeftButton)
+
+        saved = MXBIModel.model_validate_json(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(saved.mxbi_id, "mxbi-host")
+        panel.close()
+
+    def test_legacy_mxbis_option_is_ignored_and_not_exported(self) -> None:
+        options = Options.model_validate(
+            {
+                "mxbis": ["mxbi1"],
+                "experimenter": ["tester"],
+                "animals": {"abcd": "mouse"},
+            }
+        )
+
+        exported = options.model_dump()
+        self.assertNotIn("mxbis", exported)
+        self.assertEqual(exported["experimenter"], ["tester"])
+        self.assertEqual(exported["animals"], {"abcd": "mouse"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove the manually configured MXBI identifier options
- display the current system hostname as a read-only MXBI id
- persist the hostname to `MXBIModel.mxbi_id`
- retain compatibility with legacy options containing `mxbis`

## Why

The MXBI identifier represents the host running the application, so maintaining a separate selectable list is unnecessary and can become stale.

## Impact

The MXBI configuration panel now derives the identifier from `socket.gethostname()` instead of user selection. Existing legacy option files continue to load.

## Validation

- `uv run pyright`
- scoped Ruff checks for changed files
- `env QT_QPA_PLATFORM=offscreen uv run python -m unittest discover -s tests -v` (64 tests)
