### PR TITLE
refactor(logging): :recycle: migrate library logging to stdlib with optional loguru

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ class MyScene:
     def draw(self, screen: Surface) -> None: ...
 ```
 
+## Logging
+
+mxbiflow never configures logging on import. For a batteries-included
+setup, enable the optional `log` extra and call `setup_logging()` once,
+then use loguru directly:
+
+```shell
+uv add mxbiflow[log]
+```
+
+```python
+from loguru import logger
+from mxbiflow.utils.logger import setup_logging
+
+setup_logging(level="DEBUG", log_file="log/mxbi.log")
+
+logger.info("session started: {}", session_id)
+```
+
+`setup_logging()` wires mxbiflow's records into loguru and configures its
+sinks (stderr, plus an optional rotating, JSON-serialized file log).
+Because loguru's logger is a global singleton, the `logger` you import
+above is the configured one — no instance is returned. The CLI
+(`python -m mxbiflow`) enables this setup automatically.
+
+Without loguru, the library stays silent: you can handle mxbiflow's
+records with your own standard-library handlers instead.
+
 ## Installation
 
 ```shell

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "inflection>=0.5.1",
     "jinja2>=3.1.6",
     "keyring>=25.6.0",
-    "loguru>=0.7.3",
     "matplotlib>=3.10.6",
     "mss>=10.1.0",
     "numpy>=2.3.3",
@@ -28,6 +27,10 @@ dependencies = [
     "typer>=0.20.0",
     "varname>=0.15.0",
 ]
+
+[project.optional-dependencies]
+# Batteries-included logging: enables mxbiflow.utils.logger.setup_logging().
+log = ["loguru>=0.7.3"]
 
 [tool.uv.sources]
 pymotego = { path = "/Users/ccccr/repo/projects/cogmote/cogmote/pymoteGO", editable = true }
@@ -49,6 +52,7 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "loguru>=0.7.3",
     "pyright>=1.1.411",
     "ruff>=0.16.0",
 ]

--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -7,16 +7,22 @@ from pymxbi.mxbi.factory import MXBIModel
 from mxbiflow import set_base_path
 from mxbiflow.bootstrap import init_gameloop
 from mxbiflow.core.config_store import ConfigStore
-from mxbiflow.core.path import get_mxbi_config_path, get_runtime_state_path
+from mxbiflow.core.path import (
+    get_log_path,
+    get_mxbi_config_path,
+    get_runtime_state_path,
+)
 from mxbiflow.infra.post_processing import HtmlComposer, session_overview, summarize
 from mxbiflow.models.session import RuntimeStateStore
 from mxbiflow.scene import SceneManager
 from mxbiflow.scene.idle.idle import IDLE
 from mxbiflow.ui import run_wizard
+from mxbiflow.utils.logger import setup_logging
 
 
 def main() -> None:
     set_base_path(Path.cwd())
+    setup_logging(log_file=get_log_path() / "mxbi.log")
 
     scene_manager = SceneManager()
     scene_manager.register([IDLE])

--- a/src/mxbiflow/bootstrap.py
+++ b/src/mxbiflow/bootstrap.py
@@ -1,5 +1,4 @@
 import pymxbi
-from loguru import logger
 from pymxbi import MXBIModel
 
 from .core.config_store import ConfigStore
@@ -13,6 +12,7 @@ from .gameloop.game import Game
 from .models.animal import Animal, StageState
 from .models.session import RuntimeStateStore, Session, SessionConfig, SessionState
 from .scene import SceneManager
+from .utils.logger import logger
 
 
 def init_gameloop(scene_manager: SceneManager, max_fps: int = 60) -> Game:

--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -135,7 +135,7 @@ class Game:
         screenshot_path = screenshot_dir / f"screen_{timestamp}.png"
 
         pygame.image.save(self._screen, screenshot_path)
-        logger.info("screen captured: {}", screenshot_path)
+        logger.info("screen captured: %s", screenshot_path)
 
     def quit(self) -> None:
         if self._scene_manager.current is not None:

--- a/src/mxbiflow/gameloop/scheduler.py
+++ b/src/mxbiflow/gameloop/scheduler.py
@@ -1,10 +1,10 @@
-from loguru import logger
 from pygame import Event
 from pymxbi.detector.detector import DetectorEvent
 
 from ..models.session import Session
 from ..scene import SceneManager
 from ..scene.idle.idle import IDLE
+from ..utils.logger import logger
 from .detector_bridge import EVT_DETECTOR, DetectorMsg
 
 
@@ -57,7 +57,7 @@ class Scheduler:
 
         msg: DetectorMsg = event.msg
         logger.debug(
-            "detector event received: kind={}, animal={}", msg.kind, msg.animal
+            "detector event received: kind=%s, animal=%s", msg.kind, msg.animal
         )
 
         match msg.kind:

--- a/src/mxbiflow/infra/data_logger.py
+++ b/src/mxbiflow/infra/data_logger.py
@@ -51,11 +51,11 @@ class DataLogger:
             already_exists = base_dir.exists()
             base_dir.mkdir(parents=True, exist_ok=True)
         except OSError:
-            logger.exception("Failed to create data directory: {}", base_dir)
+            logger.exception("Failed to create data directory: %s", base_dir)
             raise
 
         logger.info(
-            "Data directory {}: {}",
+            "Data directory %s: %s",
             "exists" if already_exists else "created",
             base_dir,
         )
@@ -82,13 +82,13 @@ class DataLogger:
                 f.write(json_line + "\n")
 
         except TypeError as e:
-            logger.error("Data is not JSON serializable: {}", e)
+            logger.error("Data is not JSON serializable: %s", e)
             raise
         except OSError as e:
-            logger.error("Failed to write to file {}: {}", self._data_path, e)
+            logger.error("Failed to write to file %s: %s", self._data_path, e)
             raise
         except Exception as e:
-            logger.error("Unexpected error while writing data: {}", e)
+            logger.error("Unexpected error while writing data: %s", e)
             raise
 
     def _save_json(self, data: LogRecord) -> None:
@@ -97,13 +97,13 @@ class DataLogger:
             with open(self._data_path, "w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
         except TypeError as e:
-            logger.error("Data is not JSON serializable: {}", e)
+            logger.error("Data is not JSON serializable: %s", e)
             raise
         except OSError as e:
-            logger.error("Failed to write to file {}: {}", self._data_path, e)
+            logger.error("Failed to write to file %s: %s", self._data_path, e)
             raise
         except Exception as e:
-            logger.error("Unexpected error while writing JSON data: {}", e)
+            logger.error("Unexpected error while writing JSON data: %s", e)
             raise
 
     def save_csv_row(self, data: LogRecord) -> None:
@@ -120,5 +120,5 @@ class DataLogger:
                     writer.writeheader()
                 writer.writerow({k: data.get(k, "") for k in fieldnames})
         except Exception as e:
-            logger.error("Failed to write CSV row to {}: {}", csv_path, e)
+            logger.error("Failed to write CSV row to %s: %s", csv_path, e)
             raise

--- a/src/mxbiflow/utils/logger.py
+++ b/src/mxbiflow/utils/logger.py
@@ -1,21 +1,123 @@
+"""Logging utilities for mxbiflow.
+
+mxbiflow is a library, so it never configures logging by itself: log
+records are emitted through the standard library ``logging`` framework
+and stay silent until the host application configures them.
+
+For a batteries-included setup, call :func:`setup_logging` once, then
+use loguru directly::
+
+    from loguru import logger
+    from mxbiflow.utils.logger import setup_logging
+
+    setup_logging()
+    logger.info("hello")
+
+``from loguru import logger`` is the very same instance that
+``setup_logging()`` configures (loguru's logger is a global singleton),
+so no logger is returned. This requires the optional ``log`` extra.
+"""
+
+import logging
 import sys
+from pathlib import Path
 
-from loguru import logger
-
-from ..core.path import get_log_path
-
-logger.remove()
-
-logger.add(sys.stderr, level="DEBUG")
+#: The logger used across mxbiflow. A :class:`logging.NullHandler` is
+#: attached so importing the library never emits "no handler" warnings;
+#: the host application remains free to add its own handlers.
+logger = logging.getLogger("mxbiflow")
+logger.addHandler(logging.NullHandler())
 
 
-def init_logger() -> None:
-    logger.add(
-        f"{get_log_path()}/mxbi.log",
-        rotation="10 MB",
-        retention="7 days",
-        compression="zip",
-        encoding="utf-8",
-        level="DEBUG",
-        serialize=True,
-    )
+class InterceptHandler(logging.Handler):
+    """Bridge stdlib ``logging`` records into loguru (internal).
+
+    Attached to the root logger by :func:`setup_logging`. Also exported
+    for advanced users who want to wire the bridge into their own
+    logging hierarchy, e.g.::
+
+        logging.getLogger().addHandler(InterceptHandler())
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        # Imported lazily so the library itself never requires loguru.
+        from loguru import logger as loguru_logger
+
+        # Get the corresponding loguru level if it exists.
+        try:
+            level: str | int = loguru_logger.level(record.levelname).name
+        except ValueError:
+            level = record.levelno
+
+        # Find the caller frame where the logged message originated.
+        frame = logging.currentframe()
+        depth = 2
+        while frame is not None and frame.f_code.co_filename == logging.__file__:
+            frame = frame.f_back
+            depth += 1
+
+        loguru_logger.opt(depth=depth, exception=record.exc_info).log(
+            level,
+            record.getMessage(),
+        )
+
+
+def setup_logging(
+    *,
+    level: str | int = "DEBUG",
+    log_file: str | Path | None = None,
+    rotation: str = "10 MB",
+    retention: str = "7 days",
+    compression: str = "zip",
+    serialize: bool = True,
+) -> None:
+    """Configure loguru as mxbiflow's log sink (batteries-included setup).
+
+    This is a convenience for host applications that want loguru's
+    formatting, rotation and JSON serialization out of the box. It:
+
+    - attaches an :class:`InterceptHandler` to the root stdlib logger so
+      mxbiflow's records are re-emitted through loguru;
+    - resets loguru's global configuration and adds a stderr sink;
+    - optionally adds a rotating file sink (``log_file``), mirroring the
+      behaviour of the former ``init_logger()``.
+
+    After calling this, ``from loguru import logger`` gives you the
+    configured logger — loguru's logger is a global singleton, so no
+    instance is returned here.
+
+    Requires the optional ``log`` extra: ``pip install mxbiflow[log]``.
+    """
+    try:
+        from loguru import logger as loguru_logger
+    except ImportError as exc:
+        raise ImportError(
+            "setup_logging() requires the optional 'log' extra: "
+            "pip install mxbiflow[log]"
+        ) from exc
+
+    root = logging.getLogger()
+    if not any(isinstance(handler, InterceptHandler) for handler in root.handlers):
+        root.addHandler(InterceptHandler())
+
+    # Without this, the stdlib logger would inherit the root level
+    # (WARNING by default) and drop DEBUG/INFO records before they can
+    # reach the intercept handler.
+    logger.setLevel(level)
+
+    loguru_logger.remove()
+    loguru_logger.add(sys.stderr, level=level)
+
+    if log_file is not None:
+        loguru_logger.add(
+            str(log_file),
+            rotation=rotation,
+            retention=retention,
+            compression=compression,
+            encoding="utf-8",
+            level=level,
+            serialize=serialize,
+        )
+
+
+__all__ = ["InterceptHandler", "logger", "setup_logging"]

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,85 @@
+"""Tests for mxbiflow.utils.logger."""
+
+import logging
+import subprocess
+import sys
+import textwrap
+import unittest
+from typing import Any, cast
+
+from loguru import logger as loguru_logger
+
+from mxbiflow.utils.logger import logger, setup_logging
+
+
+class LoggerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Save and clear loguru's global handlers to isolate each test.
+        core = cast(Any, loguru_logger)._core
+        self._saved_loguru_handlers = dict(core.handlers)
+        core.handlers.clear()
+
+        self._root = logging.getLogger()
+        self._saved_root_handlers = list(self._root.handlers)
+
+    def tearDown(self) -> None:
+        core = cast(Any, loguru_logger)._core
+        core.handlers.clear()
+        core.handlers.update(self._saved_loguru_handlers)
+
+        self._root.handlers[:] = self._saved_root_handlers
+
+    def test_import_mxbiflow_does_not_touch_loguru(self) -> None:
+        """Importing the library must not configure loguru globally."""
+        code = textwrap.dedent(
+            """
+            import loguru
+
+            before = set(loguru.logger._core.handlers)
+            import mxbiflow
+            after = set(loguru.logger._core.handlers)
+
+            assert before == after, f"loguru handlers changed: {before} -> {after}"
+            print("SIDE_EFFECT_FREE")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        self.assertIn("SIDE_EFFECT_FREE", result.stdout)
+
+    def test_setup_logging_bridges_stdlib_records_to_loguru(self) -> None:
+        """setup_logging() must route stdlib records through loguru."""
+        records: list[str] = []
+
+        setup_logging(level="DEBUG")
+        loguru_logger.remove()
+        loguru_logger.add(records.append, format="{message}")
+
+        logger.info("bridged %s", "record")
+
+        self.assertEqual([m.rstrip("\n") for m in records], ["bridged record"])
+
+    def test_default_records_reach_user_stdlib_handler(self) -> None:
+        """Without setup_logging(), user stdlib handlers still receive records."""
+        records: list[logging.LogRecord] = []
+
+        class CaptureHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        handler = CaptureHandler()
+        logger.addHandler(handler)
+        try:
+            logger.warning("user %s", "handler")
+        finally:
+            logger.removeHandler(handler)
+
+        self.assertEqual([r.getMessage() for r in records], ["user handler"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -564,7 +564,6 @@ dependencies = [
     { name = "inflection" },
     { name = "jinja2" },
     { name = "keyring" },
-    { name = "loguru" },
     { name = "matplotlib" },
     { name = "mss" },
     { name = "numpy" },
@@ -583,8 +582,14 @@ dependencies = [
     { name = "varname" },
 ]
 
+[package.optional-dependencies]
+log = [
+    { name = "loguru" },
+]
+
 [package.dev-dependencies]
 dev = [
+    { name = "loguru" },
     { name = "pyright" },
     { name = "ruff" },
 ]
@@ -595,7 +600,7 @@ requires-dist = [
     { name = "inflection", specifier = ">=0.5.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "keyring", specifier = ">=25.6.0" },
-    { name = "loguru", specifier = ">=0.7.3" },
+    { name = "loguru", marker = "extra == 'log'", specifier = ">=0.7.3" },
     { name = "matplotlib", specifier = ">=3.10.6" },
     { name = "mss", specifier = ">=10.1.0" },
     { name = "numpy", specifier = ">=2.3.3" },
@@ -613,9 +618,11 @@ requires-dist = [
     { name = "typer", specifier = ">=0.20.0" },
     { name = "varname", specifier = ">=0.15.0" },
 ]
+provides-extras = ["log"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "loguru", specifier = ">=0.7.3" },
     { name = "pyright", specifier = ">=1.1.411" },
     { name = "ruff", specifier = ">=0.16.0" },
 ]


### PR DESCRIPTION
## Summary

The library previously forced `loguru` on host applications and configured its global logger on import. This PR makes mxbiflow logging library-friendly:

- Library emits records via stdlib `logging.getLogger("mxbiflow")` with **zero import side effects** (silent by default)
- `InterceptHandler` bridges stdlib records into loguru (standard recipe from loguru docs)
- New `setup_logging()` batteries-included helper: stderr sink + optional rotating JSON file log (absorbing the former `init_logger()`)
- `loguru` moved from runtime dependency to optional `log` extra (`mxbiflow[log]`); the CLI (`python -m mxbiflow`) enables it automatically
- All call sites migrated from `{}` to `%s` placeholders; docs updated to recommend `from loguru import logger` usage

## Usage

```python
from loguru import logger
from mxbiflow.utils.logger import setup_logging

setup_logging(level="DEBUG", log_file="log/mxbi.log")
logger.info("hello")
```

## Tests

- New `tests/test_logger.py`: import has no side effects on loguru, setup_logging bridges stdlib records, user stdlib handlers still receive records
- Full suite: 70 tests OK, pyright 0 errors, ruff clean