### PR TITLE
refactor(imports): :recycle: use relative imports within the package

### DIFF
--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -4,20 +4,20 @@ from pathlib import Path
 from pymotego.email import EmailClient
 from pymxbi.mxbi.factory import MXBIModel
 
-from mxbiflow import set_base_path
-from mxbiflow.bootstrap import init_gameloop
-from mxbiflow.core.config_store import ConfigStore
-from mxbiflow.core.path import (
+from . import set_base_path
+from .bootstrap import init_gameloop
+from .core.config_store import ConfigStore
+from .core.path import (
     get_log_path,
     get_mxbi_config_path,
     get_runtime_state_path,
 )
-from mxbiflow.infra.post_processing import HtmlComposer, session_overview, summarize
-from mxbiflow.models.session import RuntimeStateStore
-from mxbiflow.scene import SceneManager
-from mxbiflow.scene.idle.idle import IDLE
-from mxbiflow.ui import run_wizard
-from mxbiflow.utils.logger import setup_logging
+from .infra.post_processing import HtmlComposer, session_overview, summarize
+from .models.session import RuntimeStateStore
+from .scene import SceneManager
+from .scene.idle.idle import IDLE
+from .ui import run_wizard
+from .utils.logger import setup_logging
 
 
 def main() -> None:

--- a/src/mxbiflow/assets/__init__.py
+++ b/src/mxbiflow/assets/__init__.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
-from mxbiflow.assets.background import create_background as create_background
-from mxbiflow.assets.corner_button import Corner as Corner
-from mxbiflow.assets.corner_button import CornerButton as CornerButton
-from mxbiflow.assets.image_sprite import ImageSprite as ImageSprite
-from mxbiflow.assets.result_widget import ResultWidget as ResultWidget
+from .background import create_background as create_background
+from .corner_button import Corner as Corner
+from .corner_button import CornerButton as CornerButton
+from .image_sprite import ImageSprite as ImageSprite
+from .result_widget import ResultWidget as ResultWidget
 
 ROOT = Path(__file__).parent
 


### PR DESCRIPTION
## 变更内容

- `mxbiflow/__main__.py`：包内导入改为相对导入（`from .xxx`）
- `mxbiflow/assets/__init__.py`：re-export 改为相对导入

纯重构，无行为变化。已验证：`unittest` 70/70 通过，`pyright` 0 errors。