### PR TITLE
feat(crash-report): :sparkles: add crash report generation with email notification

### DIFF
--- a/src/mxbiflow/bootstrap.py
+++ b/src/mxbiflow/bootstrap.py
@@ -36,8 +36,10 @@ def init_gameloop(scene_manager: SceneManager, max_fps: int = 60) -> Game:
     This function orchestrates the initialization of all core components
     required for the MXBI game loop to function.
     """
-    mxbi = build_mxbi()
+    mxbi_config = ConfigStore(get_mxbi_config_path(), MXBIModel).value
+    mxbi = build_mxbi(mxbi_config)
     session_config = ConfigStore(get_config_session_path(), SessionConfig).value
+    session_config = session_config.model_copy(update={"mxbi": mxbi_config})
     session = init_session(session_config)
 
     detector_bridge = DetectorBridge(
@@ -53,8 +55,7 @@ def init_gameloop(scene_manager: SceneManager, max_fps: int = 60) -> Game:
     )
 
 
-def build_mxbi() -> pymxbi.MXBI:
-    mxbi_config = ConfigStore(get_mxbi_config_path(), MXBIModel).value
+def build_mxbi(mxbi_config: MXBIModel) -> pymxbi.MXBI:
     return pymxbi.build_mxbi(mxbi_config, logger)
 
 

--- a/src/mxbiflow/infra/__init__.py
+++ b/src/mxbiflow/infra/__init__.py
@@ -1,4 +1,5 @@
 from .backup import BackupMonitoringError, BackupTaskRunner
+from .crash_report import CrashReport, build_crash_report
 from .data_logger import DataLogger, DataLoggerType
 from .eventbus import EventBus, event_bus
 from .timer import FrameTimer
@@ -6,9 +7,11 @@ from .timer import FrameTimer
 __all__ = [
     "BackupMonitoringError",
     "BackupTaskRunner",
+    "CrashReport",
     "DataLogger",
     "DataLoggerType",
     "EventBus",
     "FrameTimer",
+    "build_crash_report",
     "event_bus",
 ]

--- a/src/mxbiflow/infra/crash_report.py
+++ b/src/mxbiflow/infra/crash_report.py
@@ -1,0 +1,128 @@
+"""Crash report generation for email notification.
+
+Produces a self-contained HTML report (with an optional log-file
+attachment) for a raised exception, so host applications can send an
+expected crash-report email without duplicating context gathering.
+"""
+
+import traceback
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from platform import platform, python_version
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+from pymotego import EmailAttachment
+
+from ..models.session import Session
+
+_TEMPLATE_DIR = Path(__file__).parent / "templates"
+_MAX_LOG_BYTES = 512 * 1024
+
+
+@dataclass(frozen=True)
+class CrashReport:
+    """An email-ready crash report."""
+
+    subject: str
+    html_body: str
+    attachments: tuple[EmailAttachment, ...] = ()
+
+
+def _get_jinja_env() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(_TEMPLATE_DIR),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+
+
+def _package_version(package: str) -> str:
+    try:
+        return version(package)
+    except PackageNotFoundError:
+        return "unknown"
+
+
+def _environment_summary() -> str:
+    return (
+        f"Python: {python_version()}\n"
+        f"Platform: {platform()}\n"
+        f"mxbiflow: {_package_version('mxbiflow')}\n"
+        f"pymotego: {_package_version('pymotego')}\n"
+        f"pymxbi: {_package_version('pymxbi')}"
+    )
+
+
+def _session_context(session: Session) -> str:
+    """Summary of the session's animals."""
+    try:
+        animals = [
+            f"{animal.name} ({animal.current_stage.stage_name} level "
+            f"{animal.current_stage.level}, trial {animal.trial_id})"
+            for animal in session.animals.values()
+        ]
+        return "\n".join(animals) if animals else "no animals configured"
+    except Exception:  # noqa: BLE001 - best-effort context gathering
+        return "unavailable"
+
+
+def _log_attachment(log_file: Path | None) -> EmailAttachment | None:
+    """Attach the tail of the given log file when it exists."""
+    if log_file is None or not log_file.exists():
+        return None
+    try:
+        content = log_file.read_bytes()
+        if len(content) > _MAX_LOG_BYTES:
+            content = content[-_MAX_LOG_BYTES:]
+        return EmailAttachment(filename=log_file.name, content=content)
+    except Exception:  # noqa: BLE001 - best-effort attachment gathering
+        return None
+
+
+def build_crash_report(
+    exc: BaseException,
+    session: Session,
+    log_file: Path | None = None,
+) -> CrashReport:
+    """Build an email-ready crash report for ``exc``. Never raises.
+
+    ``session`` provides the mxbi identifier and animal context;
+    ``log_file`` is attached to the email when it exists.
+    """
+    # Imported lazily: post_processing imports core.context, which would
+    # form a circular import while infra/__init__ is still initializing.
+    from .post_processing import HtmlComposer
+
+    now = datetime.now(UTC)
+    mxbi_id = session.mxbi_config.mxbi_id
+    traceback_text = "".join(
+        traceback.format_exception(type(exc), exc, exc.__traceback__)
+    )
+
+    section_html = (
+        _get_jinja_env()
+        .get_template("crash_report.html")
+        .render(
+            exception_type=f"{type(exc).__module__}.{type(exc).__qualname__}",
+            exception_message=str(exc) or "(no message)",
+            traceback_text=traceback_text,
+            environment=_environment_summary(),
+            session_context=_session_context(session),
+            crash_time=now.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z"),
+            hostname=mxbi_id,
+        )
+    )
+
+    composer = HtmlComposer(
+        title=f"Crash Report - {mxbi_id}",
+        date=now.strftime("%Y-%m-%d"),
+    )
+    composer.add_section(section_html)
+
+    attachment = _log_attachment(log_file)
+    return CrashReport(
+        subject=f"{mxbi_id} Crash Report",
+        html_body=composer.html,
+        attachments=(attachment,) if attachment is not None else (),
+    )

--- a/src/mxbiflow/infra/templates/crash_report.html
+++ b/src/mxbiflow/infra/templates/crash_report.html
@@ -1,0 +1,48 @@
+<tr>
+    <td style="padding: 24px;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #FFFFFF; border-radius: 12px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);">
+            <tr>
+                <td style="padding: 20px 24px; border-bottom: 1px solid #E2E8F0;">
+                    <h2 style="margin: 0; color: #DC2626; font-size: 16px; font-weight: 600;">Crash Report</h2>
+                </td>
+            </tr>
+            <tr>
+                <td style="padding: 16px 24px 0 24px;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                        <tr>
+                            <td width="50%" style="padding: 8px;">
+                                <div style="background-color: #FEF2F2; border-radius: 8px; padding: 12px; text-align: center;">
+                                    <div style="color: #64748B; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px;">Crash Time</div>
+                                    <div style="color: #B91C1C; font-size: 14px; font-weight: 600;">{{ crash_time }}</div>
+                                </div>
+                            </td>
+                            <td width="50%" style="padding: 8px;">
+                                <div style="background-color: #EFF6FF; border-radius: 8px; padding: 12px; text-align: center;">
+                                    <div style="color: #64748B; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 4px;">Hostname</div>
+                                    <div style="color: #1E40AF; font-size: 14px; font-weight: 600;">{{ hostname }}</div>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+            <tr>
+                <td style="padding: 16px 24px;">
+                    <div style="background-color: #FEF2F2; border-radius: 8px; padding: 12px 16px; margin-bottom: 16px;">
+                        <div style="color: #B91C1C; font-size: 13px; font-weight: 600; font-family: monospace;">{{ exception_type }}</div>
+                        <div style="color: #7F1D1D; font-size: 13px; margin-top: 4px; font-family: monospace;">{{ exception_message }}</div>
+                    </div>
+
+                    <div style="color: #64748B; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px;">Traceback</div>
+                    <pre style="background-color: #0F172A; color: #E2E8F0; border-radius: 8px; padding: 12px 16px; font-size: 12px; line-height: 1.5; overflow-x: auto; white-space: pre-wrap; word-break: break-all; margin: 0 0 16px 0;">{{ traceback_text }}</pre>
+
+                    <div style="color: #64748B; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px;">Session Context</div>
+                    <pre style="background-color: #F8FAFC; color: #334155; border-radius: 8px; padding: 12px 16px; font-size: 12px; line-height: 1.5; white-space: pre-wrap; word-break: break-all; margin: 0 0 16px 0;">{{ session_context }}</pre>
+
+                    <div style="color: #64748B; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px;">Environment</div>
+                    <pre style="background-color: #F8FAFC; color: #334155; border-radius: 8px; padding: 12px 16px; font-size: 12px; line-height: 1.5; white-space: pre-wrap; word-break: break-all; margin: 0 0 4px 0;">{{ environment }}</pre>
+                </td>
+            </tr>
+        </table>
+    </td>
+</tr>

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -15,6 +15,7 @@ from pydantic import (
     field_serializer,
     model_validator,
 )
+from pymxbi import MXBIModel
 
 from .animal import (
     Animal,
@@ -45,6 +46,8 @@ class SessionConfig(BaseModel):
     fullscreen: bool = False
 
     animals: tuple[AnimalConfig, ...] = ()
+
+    mxbi: MXBIModel = Field(default_factory=MXBIModel)
 
     @model_validator(mode="after")
     def _validate_unknown_animal_as(self) -> SessionConfig:
@@ -235,6 +238,10 @@ class Session(BaseModel):
     @property
     def animals(self) -> Mapping[str, Animal]:
         return self.state.animals
+
+    @property
+    def mxbi_config(self) -> MXBIModel:
+        return self.config.mxbi
 
     @property
     def current_animal(self) -> Animal | None:

--- a/tests/test_crash_report.py
+++ b/tests/test_crash_report.py
@@ -1,0 +1,62 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pymotego import EmailAttachment
+from pymxbi import MXBIModel
+
+from mxbiflow.core.path import set_base_path
+from mxbiflow.infra import build_crash_report
+from mxbiflow.models.session import Session, SessionConfig, SessionState
+
+
+def _make_session() -> Session:
+    return Session(
+        config=SessionConfig(mxbi=MXBIModel(mxbi_id="mxbi5")),
+        state=SessionState(),
+    )
+
+
+class BuildCrashReportTests(unittest.TestCase):
+    def test_contains_exception_info_and_traceback(self) -> None:
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            report = build_crash_report(exc, _make_session())
+
+        self.assertEqual(report.subject, "mxbi5 Crash Report")
+        self.assertIn("Crash Report - mxbi5", report.html_body)
+        self.assertIn("mxbi5", report.html_body)
+        self.assertIn("Crash Time", report.html_body)
+        self.assertIn("ValueError", report.html_body)
+        self.assertIn("boom", report.html_body)
+        self.assertIn("test_contains_exception_info_and_traceback", report.html_body)
+        self.assertIn("no animals configured", report.html_body)
+        self.assertIn("Python:", report.html_body)
+        self.assertIn("mxbiflow:", report.html_body)
+
+    def test_attaches_log_file_when_present(self) -> None:
+        with TemporaryDirectory() as tmp:
+            set_base_path(Path(tmp))
+            log_file = Path(tmp) / "log" / "mxbi.log"
+            log_file.parent.mkdir()
+            log_file.write_text("session log line", encoding="utf-8")
+
+            report = build_crash_report(ValueError("x"), _make_session(), log_file)
+
+            self.assertEqual(len(report.attachments), 1)
+            attachment = report.attachments[0]
+            self.assertIsInstance(attachment, EmailAttachment)
+            self.assertEqual(attachment.filename, "mxbi.log")
+            self.assertEqual(attachment.content, b"session log line")
+
+    def test_escapes_html_in_exception_message(self) -> None:
+        exc = ValueError("<script>alert('x')</script>")
+        report = build_crash_report(exc, _make_session())
+
+        self.assertIn("&lt;script&gt;", report.html_body)
+        self.assertNotIn("<script>alert", report.html_body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更内容
- 新增 `build_crash_report(exc, session, log_file)`：生成邮件就绪的 HTML 崩溃报告（异常类型/消息、traceback、会话上下文、环境版本、崩溃时间、Hostname 卡片、可选日志附件），永不抛异常
- 邮件 subject 为 `"{mxbi_id} Crash Report"`（与 Daily Report 格式一致）
- `SessionConfig` 嵌入 mxbi 配置：`Session.mxbi_config.mxbi_id` 可访问，快照持久化
- `bootstrap` 将 `config/mxbi.json` 合并进 session 配置

## 验证
- `uv run python -m unittest discover -s tests`：73 个测试全部通过（含 3 个 crash report 测试）
- ruff check / pyright 全绿