### PR TITLE
feat(assets): ✨ support configurable background colors

### DIFF
--- a/src/mxbiflow/assets/background.py
+++ b/src/mxbiflow/assets/background.py
@@ -1,13 +1,20 @@
 import pygame
 from pygame import Surface
+from pygame.typing import ColorLike
 
 
-def create_background(screen_size: tuple[int, int], border_width: int = 40) -> Surface:
+def create_background(
+    screen_size: tuple[int, int],
+    border_width: int = 40,
+    *,
+    border_color: ColorLike = (255, 255, 255),
+    background_color: ColorLike = (0, 0, 0),
+) -> Surface:
     width, height = screen_size
     surface = Surface(screen_size)
-    surface.fill((255, 255, 255))
-    black_rect = pygame.Rect(
+    surface.fill(border_color)
+    background_rect = pygame.Rect(
         border_width, border_width, width - 2 * border_width, height - 2 * border_width
     )
-    pygame.draw.rect(surface, (0, 0, 0), black_rect)
+    pygame.draw.rect(surface, background_color, background_rect)
     return surface

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -1,0 +1,26 @@
+import unittest
+
+from mxbiflow.assets import create_background
+
+
+class CreateBackgroundTests(unittest.TestCase):
+    def test_default_colors_are_white_border_and_black_background(self) -> None:
+        background = create_background((100, 100), border_width=10)
+
+        self.assertEqual(background.get_at((0, 0))[:3], (255, 255, 255))
+        self.assertEqual(background.get_at((50, 50))[:3], (0, 0, 0))
+
+    def test_custom_border_and_background_colors(self) -> None:
+        background = create_background(
+            (100, 100),
+            border_width=10,
+            border_color=(1, 2, 3),
+            background_color=(4, 5, 6),
+        )
+
+        self.assertEqual(background.get_at((0, 0))[:3], (1, 2, 3))
+        self.assertEqual(background.get_at((50, 50))[:3], (4, 5, 6))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional border and background colors to create_background
- preserve the existing white-border and black-background defaults
- add coverage for default and custom color rendering

## Validation
- uv run ruff check src/mxbiflow/assets/background.py tests/test_background.py
- uv run ruff format --check src/mxbiflow/assets/background.py tests/test_background.py
- uv run pyright
- env QT_QPA_PLATFORM=offscreen uv run python -m unittest tests/test_background.py