### PR TITLE
feat(session): :sparkles: track stage data paths

### DIFF
--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -125,10 +125,7 @@ class Game:
                 pass
 
     def _capture_screen(self) -> None:
-        data_path = self._session.absolute_data_path
-        if data_path is None:
-            raise RuntimeError("Session data path is not available")
-        screenshot_dir = data_path / "screenshots"
+        screenshot_dir = self._session.absolute_screenshot_data_path
         screenshot_dir.mkdir(parents=True, exist_ok=True)
 
         timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S_%f")

--- a/src/mxbiflow/infra/data_logger.py
+++ b/src/mxbiflow/infra/data_logger.py
@@ -20,17 +20,21 @@ class DataLogger:
     def __init__(
         self,
         session: Session,
-        filename: str,
-        monkey: str | None = None,
+        *,
+        animal: str,
+        stage: str,
+        filename: str = "result",
         type: DataLoggerType = DataLoggerType.JSONL,
     ) -> None:
-        if session.absolute_data_path is None:
+        if session.data_root is None:
             raise RuntimeError(
                 "Session data path is not set. Call Session.start() first."
             )
 
-        self._session_path = session.absolute_data_path
-        self._monkey = monkey
+        self._session_path = session.absolute_animal_data_path(animal)
+        self._session = session
+        self._animal = animal
+        self._stage = stage
         self._filename = filename
         self._type = type
 
@@ -42,10 +46,7 @@ class DataLogger:
         return self._data_path
 
     def _ensure_data_dir(self) -> Path:
-        if self._monkey:
-            base_dir = self._session_path / Path(self._monkey)
-        else:
-            base_dir = self._session_path
+        base_dir = self._session_path / self._stage
 
         try:
             already_exists = base_dir.exists()
@@ -64,6 +65,12 @@ class DataLogger:
 
     def _get_path(self, suffix: str) -> Path:
         return self._data_dir / f"{self._filename}{suffix}"
+
+    def _register_data_path(self) -> None:
+        self._session.register_stage_data_path(
+            animal=self._animal,
+            stage=self._stage,
+        )
 
     def save(self, data: LogRecord) -> None:
         match self._type:
@@ -91,6 +98,8 @@ class DataLogger:
             logger.error("Unexpected error while writing data: %s", e)
             raise
 
+        self._register_data_path()
+
     def _save_json(self, data: LogRecord) -> None:
         try:
             self._data_path.parent.mkdir(parents=True, exist_ok=True)
@@ -105,6 +114,8 @@ class DataLogger:
         except Exception as e:
             logger.error("Unexpected error while writing JSON data: %s", e)
             raise
+
+        self._register_data_path()
 
     def save_csv_row(self, data: LogRecord) -> None:
         csv_path = self._get_path(".csv")
@@ -122,3 +133,5 @@ class DataLogger:
         except Exception as e:
             logger.error("Failed to write CSV row to %s: %s", csv_path, e)
             raise
+
+        self._register_data_path()

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -73,6 +73,7 @@ class SessionState(ContextState):
     current_scene: str | None = None
     current_animal_name: str | None = None
     animals: dict[str, Animal] = Field(default_factory=dict)
+    stage_data_paths: dict[str, dict[str, Path]] = Field(default_factory=dict)
 
     @field_serializer("start_at", "end_at", when_used="json")
     def _serialize_timestamp(self, value: datetime | None) -> str | None:
@@ -173,6 +174,9 @@ class Session(BaseModel):
 
     _session_store: RuntimeStateStore | None = PrivateAttr(default=None)
     _snapshot_store: SessionSnapshotStore | None = PrivateAttr(default=None)
+    _animal_snapshot_stores: dict[str, SessionSnapshotStore] = PrivateAttr(
+        default_factory=dict
+    )
     _data_root: Path | None = PrivateAttr(default=None)
 
     @property
@@ -264,6 +268,54 @@ class Session(BaseModel):
             return None
         return self._data_root / self.state.data_path
 
+    @property
+    def data_root(self) -> Path | None:
+        return self._data_root
+
+    def animal_data_path(self, animal: str) -> Path:
+        if self.state.data_path is None:
+            raise RuntimeError("Session is not started")
+        if animal not in self.state.animals:
+            raise ValueError(f"animal {animal} not found")
+        return Path(animal) / self.state.data_path
+
+    def absolute_animal_data_path(self, animal: str) -> Path:
+        if self._data_root is None:
+            raise RuntimeError("Session is not started")
+        return self._data_root / self.animal_data_path(animal)
+
+    @property
+    def screenshot_data_path(self) -> Path:
+        if self.state.data_path is None:
+            raise RuntimeError("Session is not started")
+        return Path("screenshot") / self.state.data_path
+
+    @property
+    def absolute_screenshot_data_path(self) -> Path:
+        if self._data_root is None:
+            raise RuntimeError("Session is not started")
+        return self._data_root / self.screenshot_data_path
+
+    @property
+    def participant_data_paths(self) -> tuple[Path, ...]:
+        return tuple(
+            self.animal_data_path(animal) for animal in self._animal_snapshot_stores
+        )
+
+    @property
+    def stage_data_paths(self) -> Mapping[str, Mapping[str, Path]]:
+        return self.state.stage_data_paths
+
+    def register_stage_data_path(self, *, animal: str, stage: str) -> Path:
+        path = self.animal_data_path(animal) / stage
+        paths_by_animal = self.state.stage_data_paths.setdefault(stage, {})
+        if paths_by_animal.get(animal) == path:
+            return path
+
+        paths_by_animal[animal] = path
+        self.checkpoint()
+        return path
+
     def set_session_store(self, store: RuntimeStateStore) -> None:
         self._session_store = store
 
@@ -274,8 +326,11 @@ class Session(BaseModel):
         return self.model_dump(mode="json")
 
     def checkpoint(self) -> None:
+        snapshot = self.snapshot()
         if self._snapshot_store is not None:
-            self._snapshot_store.save(self.snapshot())
+            self._snapshot_store.save(snapshot)
+        for store in self._animal_snapshot_stores.values():
+            store.save(snapshot)
 
     def start(self, data_root: Path) -> None:
         if self.state.start_at is not None:
@@ -290,12 +345,6 @@ class Session(BaseModel):
             self.state.session_id
         )
 
-        absolute_data_path = self.absolute_data_path
-        assert absolute_data_path is not None
-        if self._snapshot_store is None:
-            self._snapshot_store = SessionSnapshotStore(
-                absolute_data_path / "session.json"
-            )
         self.checkpoint()
 
     def end(self) -> None:
@@ -343,7 +392,16 @@ class Session(BaseModel):
 
         self.state.current_animal_name = animal
         self._start_animal_session(next_animal)
+        if self._data_root is not None:
+            self._ensure_animal_snapshot_store(animal)
         self.checkpoint()
+
+    def _ensure_animal_snapshot_store(self, animal: str) -> None:
+        if animal in self._animal_snapshot_stores:
+            return
+        self._animal_snapshot_stores[animal] = SessionSnapshotStore(
+            self.absolute_animal_data_path(animal) / "session.json"
+        )
 
     def set_current_stage(self, stage: StageState | str) -> None:
         animal = self.require_current_animal()

--- a/tests/test_data_logger.py
+++ b/tests/test_data_logger.py
@@ -2,8 +2,10 @@ import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from unittest.mock import Mock
 
 from mxbiflow.infra.data_logger import DataLogger, DataLoggerType
+from mxbiflow.models.animal import Animal, AnimalConfig, StageState
 from mxbiflow.models.session import (
     RuntimeStateStore,
     Session,
@@ -13,9 +15,27 @@ from mxbiflow.models.session import (
 
 
 def make_session(*, session_id: int = 7) -> Session:
+    animal_config = AnimalConfig(
+        rfid_id="rfid-1",
+        name="animal-1",
+        stage="stage-1",
+    )
+    stage = StageState(stage_name="stage-1")
     return Session(
-        config=SessionConfig(),
-        state=SessionState(session_id=session_id),
+        config=SessionConfig(
+            unknown_animal_as=animal_config.name,
+            animals=(animal_config,),
+        ),
+        state=SessionState(
+            session_id=session_id,
+            animals={
+                animal_config.name: Animal(
+                    config=animal_config,
+                    current_stage_name=stage.stage_name,
+                    stages={stage.stage_name: stage},
+                )
+            },
+        ),
     )
 
 
@@ -55,46 +75,144 @@ class SessionDataPathTests(unittest.TestCase):
             assert isinstance(state, dict)
             self.assertEqual(state["data_path"], str(session.data_path))
 
-
-class DataLoggerTests(unittest.TestCase):
-    def test_loggers_share_the_session_data_path(self) -> None:
+    def test_derived_paths_keep_the_path_created_at_session_start(self) -> None:
         with TemporaryDirectory() as directory:
             session = make_session()
             session.start(Path(directory) / "data")
-            assert session.data_path is not None
-            absolute_data_path = session.absolute_data_path
-            assert absolute_data_path is not None
+            animal_path = session.animal_data_path("animal-1")
+            screenshot_path = session.screenshot_data_path
 
-            session_logger = DataLogger(
+            session.state.session_id += 1
+
+            self.assertEqual(session.animal_data_path("animal-1"), animal_path)
+            self.assertEqual(session.screenshot_data_path, screenshot_path)
+
+
+class DataLoggerTests(unittest.TestCase):
+    def test_logger_uses_animal_session_and_stage_path(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            session.start(Path(directory) / "data")
+
+            json_logger = DataLogger(
                 session=session,
-                filename="session",
+                animal="animal-1",
+                stage="stage-1",
+                filename="summary",
                 type=DataLoggerType.JSON,
             )
-            animal_logger = DataLogger(
+            jsonl_logger = DataLogger(
                 session=session,
-                filename="trials",
-                monkey="animal-1",
+                animal="animal-1",
+                stage="stage-1",
             )
 
-            self.assertEqual(
-                session_logger.path,
-                absolute_data_path / "session.json",
-            )
-            self.assertEqual(
-                animal_logger.path,
-                absolute_data_path / "animal-1" / "trials.jsonl",
-            )
-
-            session_logger.save({"session_id": session.session_id})
-            animal_logger.save({"trial_id": 1})
+            self.assertEqual(session.stage_data_paths, {})
 
             self.assertEqual(
-                json.loads(session_logger.path.read_text(encoding="utf-8")),
+                json_logger.path,
+                session.absolute_animal_data_path("animal-1")
+                / "stage-1"
+                / "summary.json",
+            )
+            self.assertEqual(
+                jsonl_logger.path,
+                session.absolute_animal_data_path("animal-1")
+                / "stage-1"
+                / "result.jsonl",
+            )
+
+            json_logger.save({"session_id": session.session_id})
+            jsonl_logger.save({"trial_id": 1})
+
+            self.assertEqual(
+                json.loads(json_logger.path.read_text(encoding="utf-8")),
                 {"session_id": session.session_id},
             )
             self.assertEqual(
-                animal_logger.path.read_text(encoding="utf-8"),
+                jsonl_logger.path.read_text(encoding="utf-8"),
                 '{"trial_id": 1}\n',
+            )
+            self.assertEqual(
+                session.stage_data_paths,
+                {
+                    "stage-1": {
+                        "animal-1": session.animal_data_path("animal-1") / "stage-1"
+                    }
+                },
+            )
+
+    def test_stage_path_is_registered_once_after_successful_save(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            session.start(Path(directory) / "data")
+            logger = DataLogger(
+                session=session,
+                animal="animal-1",
+                stage="stage-1",
+            )
+            snapshot_store = Mock()
+            session.set_snapshot_store(snapshot_store)
+
+            logger.save({"trial_id": 1})
+            logger.save({"trial_id": 2})
+
+            snapshot_store.save.assert_called_once()
+
+    def test_failed_save_does_not_register_stage_path(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            session.start(Path(directory) / "data")
+            logger = DataLogger(
+                session=session,
+                animal="animal-1",
+                stage="stage-1",
+            )
+
+            with self.assertRaises(TypeError):
+                logger.save({"invalid": object()})
+
+            self.assertEqual(session.stage_data_paths, {})
+
+    def test_csv_direct_save_registers_stage_path(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            session.start(Path(directory) / "data")
+            logger = DataLogger(
+                session=session,
+                animal="animal-1",
+                stage="stage-2",
+                type=DataLoggerType.CSV,
+            )
+
+            logger.save_csv_row({"trial_id": 1})
+
+            self.assertEqual(
+                session.stage_data_paths["stage-2"]["animal-1"],
+                session.animal_data_path("animal-1") / "stage-2",
+            )
+
+    def test_stage_paths_are_serialized_as_relative_strings(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            session.start(Path(directory) / "data")
+            DataLogger(
+                session=session,
+                animal="animal-1",
+                stage="stage-1",
+            ).save({"trial_id": 1})
+
+            state = session.snapshot()["state"]
+            assert isinstance(state, dict)
+            self.assertEqual(
+                state["stage_data_paths"],
+                {
+                    "stage-1": {
+                        "animal-1": str(
+                            session.animal_data_path("animal-1") / "stage-1"
+                        )
+                    }
+                },
             )
 
     def test_unstarted_session_is_rejected_without_creating_directories(
@@ -105,7 +223,7 @@ class DataLoggerTests(unittest.TestCase):
             session = make_session()
 
             with self.assertRaisesRegex(RuntimeError, "Session.start"):
-                DataLogger(session=session, filename="session")
+                DataLogger(session=session, animal="animal-1", stage="stage-1")
 
             self.assertFalse(data_root.exists())
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -407,8 +407,7 @@ class SessionModelTests(unittest.TestCase):
             session.set_current_animal("animal-1")
             session.add_trial()
 
-            data_path = session.absolute_data_path
-            assert data_path is not None
+            data_path = session.absolute_animal_data_path("animal-1")
             payload = json.loads(
                 (data_path / "session.json").read_text(encoding="utf-8")
             )
@@ -416,6 +415,58 @@ class SessionModelTests(unittest.TestCase):
             self.assertEqual(set(payload), {"config", "state"})
             self.assertEqual(payload["state"]["current_animal_name"], "animal-1")
             self.assertEqual(payload["state"]["animals"]["animal-1"]["trial_id"], 1)
+            self.assertEqual(
+                session.participant_data_paths,
+                (session.animal_data_path("animal-1"),),
+            )
+            absolute_data_path = session.absolute_data_path
+            assert absolute_data_path is not None
+            self.assertFalse((absolute_data_path / "session.json").exists())
+
+    def test_participant_snapshots_are_synchronized(self) -> None:
+        with TemporaryDirectory() as directory:
+            session = make_session()
+            second_config = AnimalConfig(
+                rfid_id="rfid-2",
+                name="animal-2",
+                stage="vocalization_discriminate",
+            )
+            second_stage = StageState(
+                stage_name=second_config.stage,
+                initial_level=second_config.level,
+                level=second_config.level,
+            )
+            session.config = session.config.model_copy(
+                update={"animals": (*session.config.animals, second_config)}
+            )
+            session.state.animals[second_config.name] = Animal(
+                config=second_config,
+                current_stage_name=second_stage.stage_name,
+                stages={second_stage.stage_name: second_stage},
+            )
+            session.start(Path(directory) / "data")
+
+            session.set_current_animal("animal-1")
+            session.add_trial()
+            session.set_current_animal("animal-2")
+            session.add_trial()
+            session.end()
+
+            first_path = session.absolute_animal_data_path("animal-1")
+            second_path = session.absolute_animal_data_path("animal-2")
+            first = json.loads((first_path / "session.json").read_text())
+            second = json.loads((second_path / "session.json").read_text())
+
+            self.assertEqual(first, second)
+            self.assertEqual(first["state"]["animals"]["animal-1"]["trial_id"], 1)
+            self.assertEqual(first["state"]["animals"]["animal-2"]["trial_id"], 1)
+            self.assertEqual(
+                session.participant_data_paths,
+                (
+                    session.animal_data_path("animal-1"),
+                    session.animal_data_path("animal-2"),
+                ),
+            )
 
     def test_invalid_context_access_and_state_transitions_fail_explicitly(self) -> None:
         session = make_session()


### PR DESCRIPTION
## Summary
- track per-stage, per-animal data paths after successful writes
- store participant session snapshots alongside animal data
- use dedicated screenshot and stage directories

## Validation
- uv run python -m unittest discover -s tests
- uv run pyright
- uvx ruff check src/mxbiflow/infra/data_logger.py src/mxbiflow/models/session.py tests/test_data_logger.py