### PR TITLE
feat(ui): ✨ run companion tasks in backup panel

### DIFF
--- a/src/mxbiflow/ui/__init__.py
+++ b/src/mxbiflow/ui/__init__.py
@@ -1,4 +1,4 @@
-from .backup import BackupPanel, run_backup
+from .backup import BackupPanel, BackupPanelTask, run_backup
 from .experiment_panel import ExperimentPanel
 from .mxbi_panel import MXBIPanel
 from .session_summary_panel import SessionSummaryPanel, run_session_summary
@@ -6,6 +6,7 @@ from .wizard import run_wizard
 
 __all__ = [
     "BackupPanel",
+    "BackupPanelTask",
     "ExperimentPanel",
     "MXBIPanel",
     "SessionSummaryPanel",

--- a/src/mxbiflow/ui/backup.py
+++ b/src/mxbiflow/ui/backup.py
@@ -1,3 +1,8 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum, auto
+from threading import Lock, Thread
+
 from pymotego import (
     BackupDestination,
     BackupSource,
@@ -20,6 +25,61 @@ from .application import require_application
 
 _REFRESH_INTERVAL_MS = 250
 _SUCCESS_AUTO_CLOSE_MS = 10_000
+_SPINNER_FRAMES = ("◐", "◓", "◑", "◒")
+
+
+@dataclass(frozen=True)
+class BackupPanelTask:
+    label: str
+    action: Callable[[], None]
+    enabled: bool = True
+
+
+class _PanelTaskStatus(StrEnum):
+    RUNNING = auto()
+    SUCCEEDED = auto()
+    FAILED = auto()
+    SKIPPED = auto()
+
+
+class _PanelTaskRunner:
+    def __init__(self, task: BackupPanelTask) -> None:
+        self.task = task
+        self._lock = Lock()
+        self._status = (
+            _PanelTaskStatus.RUNNING if task.enabled else _PanelTaskStatus.SKIPPED
+        )
+        self._error: Exception | None = None
+
+    @property
+    def status(self) -> _PanelTaskStatus:
+        with self._lock:
+            return self._status
+
+    @property
+    def error(self) -> Exception | None:
+        with self._lock:
+            return self._error
+
+    def start(self) -> None:
+        if not self.task.enabled:
+            return
+        Thread(
+            target=self._run,
+            name="backup-panel-task",
+            daemon=True,
+        ).start()
+
+    def _run(self) -> None:
+        try:
+            self.task.action()
+        except Exception as error:  # noqa: BLE001 - task failures are shown in the panel
+            with self._lock:
+                self._error = error
+                self._status = _PanelTaskStatus.FAILED
+        else:
+            with self._lock:
+                self._status = _PanelTaskStatus.SUCCEEDED
 
 
 def run_backup(
@@ -30,6 +90,7 @@ def run_backup(
     max_attempts: int = 3,
     refresh_interval_ms: int = _REFRESH_INTERVAL_MS,
     success_auto_close_ms: int = _SUCCESS_AUTO_CLOSE_MS,
+    task: BackupPanelTask | None = None,
 ) -> None:
     """Create a backup and show a blocking progress dialog."""
     _application = require_application()
@@ -40,6 +101,7 @@ def run_backup(
         max_attempts=max_attempts,
         refresh_interval_ms=refresh_interval_ms,
         success_auto_close_ms=success_auto_close_ms,
+        task=task,
     ).exec()
 
 
@@ -53,6 +115,7 @@ class BackupPanel(QDialog):
         max_attempts: int = 3,
         refresh_interval_ms: int = _REFRESH_INTERVAL_MS,
         success_auto_close_ms: int = _SUCCESS_AUTO_CLOSE_MS,
+        task: BackupPanelTask | None = None,
     ) -> None:
         super().__init__()
         self._runner = BackupTaskRunner(
@@ -60,10 +123,14 @@ class BackupPanel(QDialog):
             max_attempts=max_attempts,
         )
         self._runner.start(source, destination)
+        self._task_runner = _PanelTaskRunner(task) if task is not None else None
+        if self._task_runner is not None:
+            self._task_runner.start()
         self._can_close = False
         self._terminal_state_shown = False
         self._success_auto_close_ms = success_auto_close_ms
         self._remaining_seconds = 0
+        self._spinner_index = 0
 
         self._build_ui()
 
@@ -120,6 +187,17 @@ class BackupPanel(QDialog):
         )
         layout.addWidget(self._path_label)
 
+        self._task_status_label = QLabel("", self)
+        self._task_status_label.setAccessibleName("Background task status")
+        self._task_error_label = QLabel("", self)
+        self._task_error_label.setWordWrap(True)
+        self._task_error_label.setStyleSheet("color: #C62828;")
+        self._task_error_label.hide()
+        if self._task_runner is None:
+            self._task_status_label.hide()
+        layout.addWidget(self._task_status_label)
+        layout.addWidget(self._task_error_label)
+
         self._error_label = QLabel("", self)
         self._error_label.setWordWrap(True)
         self._error_label.setAccessibleName("Backup error")
@@ -146,24 +224,73 @@ class BackupPanel(QDialog):
         self._update_progress(task)
         self._update_details(task)
 
-        if self._terminal_state_shown:
-            return
-
+        backup_done = False
+        backup_error: str | None = None
         if task.status is BackupStatus.SUCCEEDED:
-            self._show_success()
+            backup_done = True
+            self._progress_bar.setRange(0, 100)
+            self._progress_bar.setValue(100)
+            self._status_label.setText("Backup succeeded. Waiting for other tasks.")
         elif task.status in {
             BackupStatus.PARTIALLY_SUCCEEDED,
             BackupStatus.FAILED,
         }:
-            self._show_failure(_task_failure_message(task))
+            backup_done = True
+            backup_error = _task_failure_message(task)
+            self._status_label.setText("Backup requires attention")
         elif not self._runner.is_monitoring:
             error = self._runner.error
-            message = (
+            backup_done = True
+            backup_error = (
                 str(error)
                 if error is not None
                 else "Backup monitoring stopped before the task completed."
             )
-            self._show_failure(message)
+            self._status_label.setText("Backup requires attention")
+
+        panel_task_done, panel_task_error = self._update_panel_task()
+        if self._terminal_state_shown or not backup_done or not panel_task_done:
+            return
+
+        errors = [error for error in (backup_error, panel_task_error) if error]
+        if errors:
+            self._show_failure("\n".join(errors))
+        else:
+            self._show_success()
+
+    def _update_panel_task(self) -> tuple[bool, str | None]:
+        runner = self._task_runner
+        if runner is None:
+            return True, None
+
+        label = runner.task.label
+        match runner.status:
+            case _PanelTaskStatus.RUNNING:
+                frame = _SPINNER_FRAMES[self._spinner_index % len(_SPINNER_FRAMES)]
+                self._spinner_index += 1
+                self._task_status_label.setStyleSheet("")
+                self._task_status_label.setText(f"{frame} {label}: In progress")
+                return False, None
+            case _PanelTaskStatus.SUCCEEDED:
+                self._task_status_label.setStyleSheet(
+                    "color: #2E7D32; font-weight: bold;"
+                )
+                self._task_status_label.setText(f"✓ {label}: Done")
+                return True, None
+            case _PanelTaskStatus.SKIPPED:
+                self._task_status_label.setStyleSheet("color: #666666;")
+                self._task_status_label.setText(f"{label}: Skipped")
+                return True, None
+            case _PanelTaskStatus.FAILED:
+                error = runner.error
+                message = str(error) if error is not None else f"{label} failed."
+                self._task_status_label.setStyleSheet(
+                    "color: #C62828; font-weight: bold;"
+                )
+                self._task_status_label.setText(f"✕ {label}: Failed")
+                self._task_error_label.setText(message)
+                self._task_error_label.show()
+                return True, message
 
     def _update_progress(self, task: BackupTask) -> None:
         progress = _task_progress_percent(task)

--- a/src/mxbiflow/ui/session_summary_panel.py
+++ b/src/mxbiflow/ui/session_summary_panel.py
@@ -143,9 +143,9 @@ class SessionSummaryPanel(QDialog):
         cancel_button.clicked.connect(self.reject)
         layout.addWidget(cancel_button)
 
-        upload_button = QPushButton("Upload", self)
-        upload_button.clicked.connect(self.accept)
-        layout.addWidget(upload_button)
+        continue_button = QPushButton("Continue", self)
+        continue_button.clicked.connect(self.accept)
+        layout.addWidget(continue_button)
         return layout
 
     def showEvent(self, event: QShowEvent) -> None:

--- a/tests/test_backup_ui.py
+++ b/tests/test_backup_ui.py
@@ -6,7 +6,7 @@ from collections import deque
 from collections.abc import Iterable
 from datetime import UTC, datetime
 from threading import Event
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -24,6 +24,8 @@ from PySide6.QtWidgets import QApplication
 from mxbiflow.infra.backup import BackupTaskRunner
 from mxbiflow.ui.backup import (
     BackupPanel,
+    BackupPanelTask,
+    _PanelTaskStatus,
     _task_progress_percent,
     run_backup,
 )
@@ -105,6 +107,7 @@ def panel_with_runner(
     runner: BackupTaskRunner,
     *,
     success_auto_close_ms: int,
+    task: BackupPanelTask | None = None,
 ) -> BackupPanel:
     with (
         patch("mxbiflow.ui.backup.BackupTaskRunner", return_value=runner),
@@ -114,6 +117,7 @@ def panel_with_runner(
             SOURCE,
             DESTINATION,
             success_auto_close_ms=success_auto_close_ms,
+            task=task,
         )
 
 
@@ -170,6 +174,85 @@ class BackupUITests(unittest.TestCase):
 
         self.assertFalse(dialog.isVisible())
         self.assertEqual(dialog._progress_bar.value(), 100)
+
+    def test_success_waits_for_background_task_and_shows_done(self) -> None:
+        task_gate = Event()
+
+        def wait_for_task_gate() -> None:
+            task_gate.wait(1)
+
+        dialog = panel_with_runner(
+            completed_runner(BackupStatus.SUCCEEDED),
+            success_auto_close_ms=5_000,
+            task=BackupPanelTask(
+                label="Daily report",
+                action=wait_for_task_gate,
+            ),
+        )
+        dialog.show()
+
+        dialog._refresh()
+        first_frame = dialog._task_status_label.text()
+        dialog._refresh()
+        second_frame = dialog._task_status_label.text()
+        self.assertNotEqual(first_frame, second_frame)
+        self.assertFalse(dialog._close_button.isEnabled())
+        self.assertFalse(dialog._auto_close_timer.isActive())
+
+        task_gate.set()
+        assert dialog._task_runner is not None
+        for _ in range(100):
+            if dialog._task_runner.status is _PanelTaskStatus.SUCCEEDED:
+                break
+            QTest.qWait(10)
+        dialog._refresh()
+
+        self.assertEqual(dialog._task_status_label.text(), "✓ Daily report: Done")
+        self.assertTrue(dialog._close_button.isEnabled())
+        self.assertTrue(dialog._auto_close_timer.isActive())
+        dialog.accept()
+
+    def test_background_task_failure_is_shown_and_requires_manual_close(self) -> None:
+        def fail() -> None:
+            raise RuntimeError("SMTP unavailable")
+
+        dialog = panel_with_runner(
+            completed_runner(BackupStatus.SUCCEEDED),
+            success_auto_close_ms=5_000,
+            task=BackupPanelTask(label="Daily report", action=fail),
+        )
+        dialog.show()
+        assert dialog._task_runner is not None
+        for _ in range(100):
+            if dialog._task_runner.status is _PanelTaskStatus.FAILED:
+                break
+            QTest.qWait(10)
+        dialog._refresh()
+
+        self.assertEqual(dialog._task_status_label.text(), "✕ Daily report: Failed")
+        self.assertIn("SMTP unavailable", dialog._task_error_label.text())
+        self.assertTrue(dialog._close_button.isEnabled())
+        self.assertFalse(dialog._auto_close_timer.isActive())
+        dialog.accept()
+
+    def test_disabled_background_task_is_shown_as_skipped(self) -> None:
+        action = Mock()
+        dialog = panel_with_runner(
+            completed_runner(BackupStatus.SUCCEEDED),
+            success_auto_close_ms=5_000,
+            task=BackupPanelTask(
+                label="Daily report",
+                action=action,
+                enabled=False,
+            ),
+        )
+        dialog.show()
+        dialog._refresh()
+
+        action.assert_not_called()
+        self.assertEqual(dialog._task_status_label.text(), "Daily report: Skipped")
+        self.assertTrue(dialog._close_button.isEnabled())
+        dialog.accept()
 
     def test_success_shows_auto_close_countdown(self) -> None:
         dialog = panel_with_runner(


### PR DESCRIPTION
## Summary
- add an optional companion task to the backup dialog
- display running, skipped, completed, and failed task states
- wait for backup and companion work before closing
- rename the session summary action to Continue

## Verification
- uv run pyright
- uv run python -m unittest tests.test_backup_ui
- uvx ruff check src/mxbiflow/ui/backup.py src/mxbiflow/ui/__init__.py tests/test_backup_ui.py