### PR TITLE
feat(backup): :sparkles: add session backup workflow

### DIFF
--- a/src/mxbiflow/bootstrap.py
+++ b/src/mxbiflow/bootstrap.py
@@ -38,12 +38,12 @@ def init_gameloop(scene_manager: SceneManager, max_fps: int = 60) -> Game:
     mxbi_config = ConfigStore(get_mxbi_config_path(), MXBIModel).value
     mxbi = build_mxbi(mxbi_config)
     session_config = ConfigStore(get_config_session_path(), SessionConfig).value
-    session_config = session_config.model_copy(update={"mxbi": mxbi_config})
-    session = init_session(session_config)
+    session = init_session(session_config, mxbi_config)
 
-    detector_bridge = DetectorBridge(
-        mxbi.detector, {i.rfid_id: i.name for i in session.animals.values()}
-    )
+    animals_map = {
+        animal.config.rfid_id: animal.config.name for animal in session.animals.values()
+    }
+    detector_bridge = DetectorBridge(mxbi.detector, animals_map)
 
     return Game(
         session,
@@ -58,7 +58,10 @@ def build_mxbi(mxbi_config: MXBIModel) -> MXBI:
     return build_driver_mxbi(mxbi_config, logger)
 
 
-def init_session(session_config: SessionConfig) -> Session:
+def init_session(
+    session_config: SessionConfig,
+    mxbi_config: MXBIModel,
+) -> Session:
     store = RuntimeStateStore(get_runtime_state_path())
 
     animal_dict: dict[str, Animal] = {}
@@ -77,6 +80,7 @@ def init_session(session_config: SessionConfig) -> Session:
 
     session = Session(
         config=session_config,
+        mxbi_config=mxbi_config,
         state=SessionState(animals=animal_dict),
     )
     session.set_session_store(store)

--- a/src/mxbiflow/driver/mxbi/factory.py
+++ b/src/mxbiflow/driver/mxbi/factory.py
@@ -24,6 +24,8 @@ from .mxbi import MXBI
 class MXBIModel(BaseModel):
     mxbi_id: str = Field(default="debug")
     screen_size: tuple[int, int] = Field(default=(1024, 600))
+    backup_source_root_id: str
+    backup_destination_root_id: str
     rewarders: list[RewarderModel] = Field(default_factory=list)
     detectors: list[DetectorModel] = Field(default_factory=list)
 

--- a/src/mxbiflow/infra/crash_report.py
+++ b/src/mxbiflow/infra/crash_report.py
@@ -57,7 +57,7 @@ def _session_context(session: Session) -> str:
     """Summary of the session's animals."""
     try:
         animals = [
-            f"{animal.name} ({animal.current_stage.stage_name} level "
+            f"{animal.config.name} ({animal.current_stage.stage_name} level "
             f"{animal.current_stage.level}, trial {animal.trial_id})"
             for animal in session.animals.values()
         ]

--- a/src/mxbiflow/infra/post_processing.py
+++ b/src/mxbiflow/infra/post_processing.py
@@ -99,7 +99,7 @@ def summarize() -> SessionSummary:
         animal_summaries.append(
             AnimalSummary(
                 name=name,
-                rfid_id=animal.rfid_id,
+                rfid_id=animal.config.rfid_id,
                 total_trials=animal.trial_id,
                 animal_sessions=len(animal.animal_sessions),
                 total_duration_seconds=_calc_animal_duration(animal.animal_sessions),

--- a/src/mxbiflow/models/animal.py
+++ b/src/mxbiflow/models/animal.py
@@ -129,7 +129,7 @@ class Animal(ContextState):
             raise ValueError("Animal session is not started")
 
         return AnimalBaseInfo(
-            animal=self.name,
+            animal=self.config.name,
             trial_id=self.trial_id,
             level=self.current_stage.level,
             level_trial_id=self.current_stage.level_trial_id,

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -48,8 +48,6 @@ class SessionConfig(BaseModel):
 
     animals: tuple[AnimalConfig, ...] = ()
 
-    mxbi: MXBIModel = Field(default_factory=MXBIModel)
-
     @model_validator(mode="after")
     def _validate_unknown_animal_as(self) -> SessionConfig:
         if not self.animals:
@@ -171,6 +169,7 @@ class SessionSnapshotStore:
 
 class Session(BaseModel):
     config: SessionConfig
+    mxbi_config: MXBIModel = Field(exclude=True)
     state: SessionState
 
     _session_store: RuntimeStateStore | None = PrivateAttr(default=None)
@@ -243,10 +242,6 @@ class Session(BaseModel):
     @property
     def animals(self) -> Mapping[str, Animal]:
         return self.state.animals
-
-    @property
-    def mxbi_config(self) -> MXBIModel:
-        return self.config.mxbi
 
     @property
     def current_animal(self) -> Animal | None:

--- a/src/mxbiflow/ui/__init__.py
+++ b/src/mxbiflow/ui/__init__.py
@@ -1,4 +1,4 @@
-from .backup import BackupPanel, BackupPanelTask, run_backup
+from .backup import BackupPanel, BackupPanelTask, run_backup, run_session_backup
 from .experiment_panel import ExperimentPanel
 from .mxbi_panel import MXBIPanel
 from .session_summary_panel import SessionSummaryPanel, run_session_summary
@@ -11,6 +11,7 @@ __all__ = [
     "MXBIPanel",
     "SessionSummaryPanel",
     "run_backup",
+    "run_session_backup",
     "run_session_summary",
     "run_wizard",
 ]

--- a/src/mxbiflow/ui/backup.py
+++ b/src/mxbiflow/ui/backup.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import (
 )
 
 from ..infra.backup import BackupTaskRunner
+from ..models.session import Session
 from .application import require_application
 
 _REFRESH_INTERVAL_MS = 250
@@ -103,6 +104,23 @@ def run_backup(
         success_auto_close_ms=success_auto_close_ms,
         task=task,
     ).exec()
+
+
+def run_session_backup(session: Session) -> None:
+    """Back up all data produced by a completed session."""
+    entries = list(session.participant_data_paths)
+    if not entries:
+        raise RuntimeError("Session has no data available for backup")
+
+    run_backup(
+        BackupSource(
+            root_id=session.mxbi_config.backup_source_root_id,
+            entries=tuple(path.as_posix() for path in entries),
+        ),
+        BackupDestination(
+            root_id=session.mxbi_config.backup_destination_root_id,
+        ),
+    )
 
 
 class BackupPanel(QDialog):

--- a/src/mxbiflow/ui/components/baseconfig.py
+++ b/src/mxbiflow/ui/components/baseconfig.py
@@ -7,6 +7,7 @@ from PySide6.QtWidgets import (
     QFormLayout,
     QGroupBox,
     QLabel,
+    QLineEdit,
     QSpinBox,
     QWidget,
 )
@@ -37,6 +38,18 @@ class BaseConfig(QGroupBox):
             )
         self._layout.addRow(self._label_screen, self._combo_screen)
 
+        self.input_backup_source_root_id = QLineEdit()
+        self._layout.addRow(
+            "backup source root id:",
+            self.input_backup_source_root_id,
+        )
+
+        self.input_backup_destination_root_id = QLineEdit()
+        self._layout.addRow(
+            "backup destination root id:",
+            self.input_backup_destination_root_id,
+        )
+
         self._label_auto_accept = QLabel("auto accept (s):")
         self._spin_auto_accept = QSpinBox()
         self._spin_auto_accept.setRange(0, 3600)
@@ -55,11 +68,21 @@ class BaseConfig(QGroupBox):
     def auto_accept_timeout(self) -> int:
         return self._spin_auto_accept.value()
 
+    @property
+    def backup_source_root_id(self) -> str:
+        return self.input_backup_source_root_id.text()
+
+    @property
+    def backup_destination_root_id(self) -> str:
+        return self.input_backup_destination_root_id.text()
+
     def load_from_model(self, model: MXBIModel) -> None:
         for i in range(self._combo_screen.count()):
             if self._combo_screen.itemData(i) == tuple(model.screen_size):
                 self._combo_screen.setCurrentIndex(i)
                 break
+        self.input_backup_source_root_id.setText(model.backup_source_root_id)
+        self.input_backup_destination_root_id.setText(model.backup_destination_root_id)
 
     def load_auto_accept_timeout(self, timeout_seconds: int) -> None:
         self._spin_auto_accept.setValue(timeout_seconds)
@@ -67,3 +90,5 @@ class BaseConfig(QGroupBox):
     def apply_to_model(self, model: MXBIModel) -> None:
         model.mxbi_id = self.mxbi_id
         model.screen_size = self._combo_screen.currentData()
+        model.backup_source_root_id = self.backup_source_root_id
+        model.backup_destination_root_id = self.backup_destination_root_id

--- a/tests/test_backup_ui.py
+++ b/tests/test_backup_ui.py
@@ -5,7 +5,9 @@ import unittest
 from collections import deque
 from collections.abc import Iterable
 from datetime import UTC, datetime
+from pathlib import Path
 from threading import Event
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
@@ -28,6 +30,7 @@ from mxbiflow.ui.backup import (
     _PanelTaskStatus,
     _task_progress_percent,
     run_backup,
+    run_session_backup,
 )
 
 SOURCE = BackupSource(root_id="project-data", entries=("run-01",))
@@ -364,6 +367,47 @@ class BackupUITests(unittest.TestCase):
             )
 
         self.assertTrue(client.closed)
+
+    @patch("mxbiflow.ui.backup.run_backup")
+    def test_session_backup_uses_configured_roots_and_participant_paths(
+        self,
+        run_backup_mock: Mock,
+    ) -> None:
+        session = Mock()
+        session.participant_data_paths = (
+            Path("animal-1/20260805/1"),
+            Path("animal-2/20260805/1"),
+        )
+        session.mxbi_config = SimpleNamespace(
+            backup_source_root_id="mxbi-data",
+            backup_destination_root_id="mxbi-server",
+        )
+
+        run_session_backup(session)
+
+        source, destination = run_backup_mock.call_args.args
+        self.assertEqual(source.root_id, "mxbi-data")
+        self.assertEqual(
+            source.entries,
+            (
+                "animal-1/20260805/1",
+                "animal-2/20260805/1",
+            ),
+        )
+        self.assertEqual(destination.root_id, "mxbi-server")
+
+    @patch("mxbiflow.ui.backup.run_backup")
+    def test_session_backup_rejects_session_without_data(
+        self,
+        run_backup_mock: Mock,
+    ) -> None:
+        session = Mock()
+        session.participant_data_paths = ()
+
+        with self.assertRaisesRegex(RuntimeError, "no data"):
+            run_session_backup(session)
+
+        run_backup_mock.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_baseconfig_ui.py
+++ b/tests/test_baseconfig_ui.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
+from pydantic import ValidationError
 from PySide6.QtCore import Qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QLabel
@@ -47,7 +48,11 @@ class BaseConfigTests(unittest.TestCase):
         config_path = get_mxbi_config_path()
         config_path.parent.mkdir(parents=True, exist_ok=True)
         config_path.write_text(
-            MXBIModel(mxbi_id="outdated").model_dump_json(indent=4),
+            MXBIModel(
+                mxbi_id="outdated",
+                backup_source_root_id="original-source",
+                backup_destination_root_id="original-destination",
+            ).model_dump_json(indent=4),
             encoding="utf-8",
         )
 
@@ -60,6 +65,39 @@ class BaseConfigTests(unittest.TestCase):
         saved = MXBIModel.model_validate_json(config_path.read_text(encoding="utf-8"))
         self.assertEqual(saved.mxbi_id, "mxbi-host")
         panel.close()
+
+    def test_backup_root_ids_are_loaded_and_saved(self) -> None:
+        config_path = get_mxbi_config_path()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            MXBIModel(
+                backup_source_root_id="original-source",
+                backup_destination_root_id="original-destination",
+            ).model_dump_json(indent=4),
+            encoding="utf-8",
+        )
+
+        panel = MXBIPanel()
+        self.assertEqual(panel.base_config.backup_source_root_id, "original-source")
+        self.assertEqual(
+            panel.base_config.backup_destination_root_id,
+            "original-destination",
+        )
+
+        panel.base_config.input_backup_source_root_id.setText("updated-source")
+        panel.base_config.input_backup_destination_root_id.setText(
+            "updated-destination"
+        )
+        QTest.mouseClick(panel.save_button, Qt.MouseButton.LeftButton)
+
+        saved = MXBIModel.model_validate_json(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(saved.backup_source_root_id, "updated-source")
+        self.assertEqual(saved.backup_destination_root_id, "updated-destination")
+        panel.close()
+
+    def test_backup_root_ids_are_required(self) -> None:
+        with self.assertRaises(ValidationError):
+            MXBIModel.model_validate({})
 
     def test_legacy_mxbis_option_is_ignored_and_not_exported(self) -> None:
         database = MXBIDatabase.model_validate(

--- a/tests/test_countdown_ui.py
+++ b/tests/test_countdown_ui.py
@@ -10,7 +10,12 @@ from PySide6.QtCore import Qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QDialog, QLabel, QPushButton, QSpinBox
 
-from mxbiflow.core.path import get_mxbi_panel_config_path, set_base_path
+from mxbiflow.core.path import (
+    get_mxbi_config_path,
+    get_mxbi_panel_config_path,
+    set_base_path,
+)
+from mxbiflow.driver import MXBIModel
 from mxbiflow.models.panel import MXBIPanelConfig
 from mxbiflow.scene import SceneManager
 from mxbiflow.ui.components.countdown import AutoAcceptCountdown
@@ -103,6 +108,15 @@ class PanelCountdownTests(unittest.TestCase):
         )
         self._home_patch.start()
         set_base_path(Path(self._temporary_directory.name))
+        config_path = get_mxbi_config_path()
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            MXBIModel(
+                backup_source_root_id="source",
+                backup_destination_root_id="destination",
+            ).model_dump_json(indent=4),
+            encoding="utf-8",
+        )
 
     def tearDown(self) -> None:
         self.application.processEvents()

--- a/tests/test_crash_report.py
+++ b/tests/test_crash_report.py
@@ -12,7 +12,12 @@ from mxbiflow.models.session import Session, SessionConfig, SessionState
 
 def _make_session() -> Session:
     return Session(
-        config=SessionConfig(mxbi=MXBIModel(mxbi_id="mxbi5")),
+        config=SessionConfig(),
+        mxbi_config=MXBIModel(
+            mxbi_id="mxbi5",
+            backup_source_root_id="source",
+            backup_destination_root_id="destination",
+        ),
         state=SessionState(),
     )
 

--- a/tests/test_data_logger.py
+++ b/tests/test_data_logger.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 
+from mxbiflow.driver import MXBIModel
 from mxbiflow.infra.data_logger import DataLogger, DataLoggerType
 from mxbiflow.models.animal import Animal, AnimalConfig, StageState
 from mxbiflow.models.session import (
@@ -25,6 +26,10 @@ def make_session(*, session_id: int = 7) -> Session:
         config=SessionConfig(
             unknown_animal_as=animal_config.name,
             animals=(animal_config,),
+        ),
+        mxbi_config=MXBIModel(
+            backup_source_root_id="source",
+            backup_destination_root_id="destination",
         ),
         state=SessionState(
             session_id=session_id,

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2,6 +2,7 @@ import unittest
 
 from pygame import Event, Surface
 
+from mxbiflow.driver import MXBIModel
 from mxbiflow.driver.detector.detector import DetectorEvent
 from mxbiflow.gameloop.detector_bridge import EVT_DETECTOR, DetectorMsg
 from mxbiflow.gameloop.scheduler import Scheduler
@@ -40,6 +41,10 @@ class SchedulerTests(unittest.TestCase):
             config=SessionConfig(
                 unknown_animal_as=animal_config.name,
                 animals=(animal_config,),
+            ),
+            mxbi_config=MXBIModel(
+                backup_source_root_id="source",
+                backup_destination_root_id="destination",
             ),
             state=SessionState(animals={animal.name: animal}),
         )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from pydantic import BaseModel, ValidationError
 
 from mxbiflow.bootstrap import init_session
+from mxbiflow.driver import MXBIModel
 from mxbiflow.models.animal import Animal, AnimalConfig, StageSnapshot, StageState
 from mxbiflow.models.session import (
     EmailRuntimeState,
@@ -60,6 +61,10 @@ def make_session() -> Session:
     )
     return Session(
         config=config,
+        mxbi_config=MXBIModel(
+            backup_source_root_id="source",
+            backup_destination_root_id="destination",
+        ),
         state=SessionState(animals={animal.name: animal}),
     )
 
@@ -177,6 +182,10 @@ class SessionModelTests(unittest.TestCase):
             stage="vocalization_discriminate",
             level=2,
         )
+        mxbi_config = MXBIModel(
+            backup_source_root_id="source",
+            backup_destination_root_id="destination",
+        )
 
         with patch(
             "mxbiflow.bootstrap.get_runtime_state_path",
@@ -186,11 +195,13 @@ class SessionModelTests(unittest.TestCase):
                 SessionConfig(
                     unknown_animal_as=animal_config.name,
                     animals=(animal_config,),
-                )
+                ),
+                mxbi_config,
             )
         animal = session.animals["animal-1"]
 
         self.assertIs(animal.config, session.config.animals[0])
+        self.assertIs(session.mxbi_config, mxbi_config)
         self.assertEqual(animal.rfid_id, "rfid-1")
         self.assertEqual(animal.name, "animal-1")
 


### PR DESCRIPTION
## Summary
- add a high-level session backup entry point backed by participant data paths
- move backup root IDs into editable MXBI configuration
- separate runtime MXBI configuration from persisted session configuration
- resolve strict typing at animal configuration boundaries

## Validation
- uv run --frozen python -m unittest discover -s tests
- uv run --frozen pyright
- uvx ruff check .