### PR TITLE
feat(crash-report): :sparkles: add crash report delivery

### DIFF
--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from . import get_mxbiflow, set_base_path
 from .bootstrap import init_gameloop
 from .core.path import get_log_path
+from .infra import send_crash_report
+from .models.session import Session
 from .scene import SceneManager
 from .scene.idle.idle import IDLE
 from .ui import run_session_post_processing, run_wizard
@@ -11,17 +13,22 @@ from .utils.logger import setup_logging
 
 def main() -> None:
     set_base_path(Path.cwd())
-    setup_logging(log_file=get_log_path() / "mxbi.log")
+    log_file = get_log_path() / "mxbi.log"
+    setup_logging(log_file=log_file)
 
     scene_manager = SceneManager()
     scene_manager.register([IDLE])
-
-    if not run_wizard(scene_manager):
-        return
-
-    game = init_gameloop(scene_manager)
-    game.play()
-    run_session_post_processing(get_mxbiflow().session, {})
+    session: Session | None = None
+    try:
+        if not run_wizard(scene_manager):
+            return
+        session = get_mxbiflow().session
+        game = init_gameloop(scene_manager)
+        game.play()
+        run_session_post_processing(session, {})
+    except Exception as exc:
+        send_crash_report(exc, session, log_file)
+        raise
 
 
 if __name__ == "__main__":

--- a/src/mxbiflow/infra/__init__.py
+++ b/src/mxbiflow/infra/__init__.py
@@ -1,5 +1,5 @@
 from .backup import BackupMonitoringError, BackupTaskRunner
-from .crash_report import CrashReport, build_crash_report
+from .crash_report import CrashReport, build_crash_report, send_crash_report
 from .data_logger import DataLogger, DataLoggerType
 from .eventbus import EventBus, event_bus
 from .timer import FrameTimer
@@ -14,4 +14,5 @@ __all__ = [
     "FrameTimer",
     "build_crash_report",
     "event_bus",
+    "send_crash_report",
 ]

--- a/src/mxbiflow/infra/crash_report.py
+++ b/src/mxbiflow/infra/crash_report.py
@@ -13,7 +13,8 @@ from pathlib import Path
 from platform import platform, python_version
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
-from pymotego import EmailAttachment
+from loguru import logger
+from pymotego import EmailAttachment, EmailClient
 
 from ..models.session import Session
 
@@ -125,3 +126,26 @@ def build_crash_report(
         html_body=composer.html,
         attachments=(attachment,) if attachment is not None else (),
     )
+
+
+def send_crash_report(
+    exc: BaseException,
+    session: Session | None,
+    log_file: Path | None = None,
+) -> None:
+    """Send a crash report without masking the original exception."""
+    if session is None:
+        logger.warning("crash before session init; skipping crash report")
+        return
+
+    try:
+        report = build_crash_report(exc, session, log_file)
+        with EmailClient() as client:
+            client.send(
+                subject=report.subject,
+                html_body=report.html_body,
+                attachments=report.attachments,
+            )
+        logger.info("crash report sent: {}", report.subject)
+    except Exception:  # noqa: BLE001 - never mask the original exception
+        logger.exception("failed to send crash report email")

--- a/tests/test_crash_report.py
+++ b/tests/test_crash_report.py
@@ -1,12 +1,14 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from pymotego import EmailAttachment
 
 from mxbiflow.core.path import set_base_path
 from mxbiflow.driver import MXBIModel
-from mxbiflow.infra import build_crash_report
+from mxbiflow.infra import build_crash_report, send_crash_report
 from mxbiflow.models.session import Session, SessionConfig, SessionState
 
 
@@ -61,6 +63,58 @@ class BuildCrashReportTests(unittest.TestCase):
 
         self.assertIn("&lt;script&gt;", report.html_body)
         self.assertNotIn("<script>alert", report.html_body)
+
+
+class SendCrashReportTests(unittest.TestCase):
+    @patch("mxbiflow.infra.crash_report.EmailClient")
+    @patch("mxbiflow.infra.crash_report.build_crash_report")
+    def test_sends_built_report(
+        self,
+        build_report: Mock,
+        email_client_cls: Mock,
+    ) -> None:
+        report = SimpleNamespace(
+            subject="mxbi5 Crash Report",
+            html_body="<html>boom</html>",
+            attachments=(),
+        )
+        build_report.return_value = report
+        email_client = email_client_cls.return_value.__enter__.return_value
+        error = RuntimeError("boom")
+        session = _make_session()
+        log_file = Path("mxbi.log")
+
+        send_crash_report(error, session, log_file)
+
+        build_report.assert_called_once_with(error, session, log_file)
+        email_client.send.assert_called_once_with(
+            subject=report.subject,
+            html_body=report.html_body,
+            attachments=report.attachments,
+        )
+
+    @patch("mxbiflow.infra.crash_report.EmailClient", side_effect=RuntimeError)
+    @patch("mxbiflow.infra.crash_report.build_crash_report", return_value=Mock())
+    def test_send_failure_is_suppressed(
+        self,
+        _build_report: Mock,
+        _email_client_cls: Mock,
+    ) -> None:
+        send_crash_report(ValueError("original"), _make_session())
+
+    @patch("mxbiflow.infra.crash_report.logger.warning")
+    @patch("mxbiflow.infra.crash_report.build_crash_report")
+    def test_missing_session_skips_report(
+        self,
+        build_report: Mock,
+        warning: Mock,
+    ) -> None:
+        send_crash_report(RuntimeError("boom"), None)
+
+        build_report.assert_not_called()
+        warning.assert_called_once_with(
+            "crash before session init; skipping crash report"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add shared crash report email delivery to mxbiflow
- suppress delivery errors so the original application exception is preserved
- integrate the shared flow into the built-in entrypoint

## Validation
- uv run --frozen python -m unittest discover -s tests
- uv run --frozen pyright
- uvx ruff check .