### PR TITLE
feat(logging): :sparkles: add default log file handling

### DIFF
--- a/src/mxbiflow/__main__.py
+++ b/src/mxbiflow/__main__.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 from . import get_mxbiflow, set_base_path
 from .bootstrap import init_gameloop
-from .core.path import get_log_path
 from .infra import send_crash_report
 from .models.session import Session
 from .scene import SceneManager
@@ -13,8 +12,7 @@ from .utils.logger import setup_logging
 
 def main() -> None:
     set_base_path(Path.cwd())
-    log_file = get_log_path() / "mxbi.log"
-    setup_logging(log_file=log_file)
+    setup_logging()
 
     scene_manager = SceneManager()
     scene_manager.register([IDLE])
@@ -27,7 +25,7 @@ def main() -> None:
         game.play()
         run_session_post_processing(session, {})
     except Exception as exc:
-        send_crash_report(exc, session, log_file)
+        send_crash_report(exc, session)
         raise
 
 

--- a/src/mxbiflow/core/path.py
+++ b/src/mxbiflow/core/path.py
@@ -8,6 +8,7 @@ DATABASE_FILENAME = "db.json"
 MXBI_CONFIG_FILENAME = "mxbi.json"
 MXBI_PANEL_CONFIG_FILENAME = "mxbi_panel.json"
 CROSS_MODAL_CONFIG_FILENAME = "config_cross_modal.json"
+DEFAULT_LOG_FILENAME = "mxbi.log"
 
 
 def set_base_path(path: Path | str) -> None:
@@ -51,6 +52,10 @@ def get_data_dir_path() -> Path:
 
 def get_log_path() -> Path:
     return get_base_path() / "log"
+
+
+def get_default_log_file_path() -> Path:
+    return get_log_path() / DEFAULT_LOG_FILENAME
 
 
 def get_internal_state_path() -> Path:

--- a/src/mxbiflow/infra/crash_report.py
+++ b/src/mxbiflow/infra/crash_report.py
@@ -16,10 +16,18 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from loguru import logger
 from pymotego import EmailAttachment, EmailClient
 
+from ..core.path import get_default_log_file_path
 from ..models.session import Session
 
 _TEMPLATE_DIR = Path(__file__).parent / "templates"
 _MAX_LOG_BYTES = 512 * 1024
+
+
+class _DefaultLogFile:
+    pass
+
+
+_DEFAULT_LOG_FILE = _DefaultLogFile()
 
 
 @dataclass(frozen=True)
@@ -131,7 +139,7 @@ def build_crash_report(
 def send_crash_report(
     exc: BaseException,
     session: Session | None,
-    log_file: Path | None = None,
+    log_file: Path | None | _DefaultLogFile = _DEFAULT_LOG_FILE,
 ) -> None:
     """Send a crash report without masking the original exception."""
     if session is None:
@@ -139,7 +147,12 @@ def send_crash_report(
         return
 
     try:
-        report = build_crash_report(exc, session, log_file)
+        resolved_log_file = (
+            get_default_log_file_path()
+            if isinstance(log_file, _DefaultLogFile)
+            else log_file
+        )
+        report = build_crash_report(exc, session, resolved_log_file)
         with EmailClient() as client:
             client.send(
                 subject=report.subject,

--- a/src/mxbiflow/utils/logger.py
+++ b/src/mxbiflow/utils/logger.py
@@ -22,11 +22,20 @@ import logging
 import sys
 from pathlib import Path
 
+from ..core.path import get_default_log_file_path
+
 #: The logger used across mxbiflow. A :class:`logging.NullHandler` is
 #: attached so importing the library never emits "no handler" warnings;
 #: the host application remains free to add its own handlers.
 logger = logging.getLogger("mxbiflow")
 logger.addHandler(logging.NullHandler())
+
+
+class _DefaultLogFile:
+    pass
+
+
+_DEFAULT_LOG_FILE = _DefaultLogFile()
 
 
 class InterceptHandler(logging.Handler):
@@ -65,7 +74,7 @@ class InterceptHandler(logging.Handler):
 def setup_logging(
     *,
     level: str | int = "DEBUG",
-    log_file: str | Path | None = None,
+    log_file: str | Path | None | _DefaultLogFile = _DEFAULT_LOG_FILE,
     rotation: str = "10 MB",
     retention: str = "7 days",
     compression: str = "zip",
@@ -79,8 +88,8 @@ def setup_logging(
     - attaches an :class:`InterceptHandler` to the root stdlib logger so
       mxbiflow's records are re-emitted through loguru;
     - resets loguru's global configuration and adds a stderr sink;
-    - optionally adds a rotating file sink (``log_file``), mirroring the
-      behaviour of the former ``init_logger()``.
+    - adds a rotating file sink at mxbiflow's default log path unless
+      ``log_file=None`` explicitly disables it.
 
     After calling this, ``from loguru import logger`` gives you the
     configured logger — loguru's logger is a global singleton, so no
@@ -108,9 +117,14 @@ def setup_logging(
     loguru_logger.remove()
     loguru_logger.add(sys.stderr, level=level)
 
-    if log_file is not None:
+    resolved_log_file = (
+        get_default_log_file_path()
+        if isinstance(log_file, _DefaultLogFile)
+        else log_file
+    )
+    if resolved_log_file is not None:
         loguru_logger.add(
-            str(log_file),
+            str(resolved_log_file),
             rotation=rotation,
             retention=retention,
             compression=compression,

--- a/tests/test_crash_report.py
+++ b/tests/test_crash_report.py
@@ -93,6 +93,40 @@ class SendCrashReportTests(unittest.TestCase):
             attachments=report.attachments,
         )
 
+    @patch("mxbiflow.infra.crash_report.get_default_log_file_path")
+    @patch("mxbiflow.infra.crash_report.EmailClient")
+    @patch("mxbiflow.infra.crash_report.build_crash_report")
+    def test_uses_default_log_file_when_omitted(
+        self,
+        build_report: Mock,
+        _email_client_cls: Mock,
+        get_default_log_file_path: Mock,
+    ) -> None:
+        error = RuntimeError("boom")
+        session = _make_session()
+        get_default_log_file_path.return_value = Path("log/mxbi.log")
+
+        send_crash_report(error, session)
+
+        build_report.assert_called_once_with(error, session, Path("log/mxbi.log"))
+
+    @patch("mxbiflow.infra.crash_report.get_default_log_file_path")
+    @patch("mxbiflow.infra.crash_report.EmailClient")
+    @patch("mxbiflow.infra.crash_report.build_crash_report")
+    def test_explicit_none_disables_log_attachment(
+        self,
+        build_report: Mock,
+        _email_client_cls: Mock,
+        get_default_log_file_path: Mock,
+    ) -> None:
+        error = RuntimeError("boom")
+        session = _make_session()
+
+        send_crash_report(error, session, log_file=None)
+
+        get_default_log_file_path.assert_not_called()
+        build_report.assert_called_once_with(error, session, None)
+
     @patch("mxbiflow.infra.crash_report.EmailClient", side_effect=RuntimeError)
     @patch("mxbiflow.infra.crash_report.build_crash_report", return_value=Mock())
     def test_send_failure_is_suppressed(

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -5,10 +5,13 @@ import subprocess
 import sys
 import textwrap
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Any, cast
 
 from loguru import logger as loguru_logger
 
+from mxbiflow.core.path import get_default_log_file_path, set_base_path
 from mxbiflow.utils.logger import logger, setup_logging
 
 
@@ -55,13 +58,25 @@ class LoggerTests(unittest.TestCase):
         """setup_logging() must route stdlib records through loguru."""
         records: list[str] = []
 
-        setup_logging(level="DEBUG")
+        setup_logging(level="DEBUG", log_file=None)
         loguru_logger.remove()
         loguru_logger.add(records.append, format="{message}")
 
         logger.info("bridged %s", "record")
 
         self.assertEqual([m.rstrip("\n") for m in records], ["bridged record"])
+
+    def test_setup_logging_uses_default_log_file(self) -> None:
+        with TemporaryDirectory() as directory:
+            set_base_path(directory)
+
+            setup_logging(level="INFO")
+            loguru_logger.info("default file record")
+
+            log_file = Path(directory) / "log" / "mxbi.log"
+            self.assertEqual(get_default_log_file_path(), log_file)
+            self.assertIn("default file record", log_file.read_text(encoding="utf-8"))
+            loguru_logger.remove()
 
     def test_default_records_reach_user_stdlib_handler(self) -> None:
         """Without setup_logging(), user stdlib handlers still receive records."""


### PR DESCRIPTION
## Summary
- use `log/mxbi.log` when logging is configured without an explicit file
- attach the default log to crash reports while preserving explicit `None` opt-out behavior
- simplify built-in startup logging configuration

## Verification
- `uv run --frozen python -m unittest discover -s tests` (98 tests)
- `uv run --frozen pyright`
- `uvx ruff check .`