### PR TITLE
feat(scene): :sparkles: standardize scene names as snake case

### DIFF
--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -68,9 +68,7 @@ class Game:
         self._scene_manager.init()
 
         if self._scene_manager.current is not None:
-            self._session.set_current_scene(
-                type(self._scene_manager.current).__name__.lower()
-            )
+            self._session.set_current_scene(type(self._scene_manager.current).name())
         self._session.start(get_data_dir_path())
 
     def play(self) -> None:
@@ -98,7 +96,7 @@ class Game:
                 and self._scene_manager.current is not None
             ):
                 self._session.set_current_scene(
-                    type(self._scene_manager.current).__name__.lower()
+                    type(self._scene_manager.current).name()
                 )
 
             pygame.display.flip()

--- a/src/mxbiflow/gameloop/scheduler.py
+++ b/src/mxbiflow/gameloop/scheduler.py
@@ -99,7 +99,7 @@ class Scheduler:
 
         if animal is None:
             if not isinstance(self._scene_manager.current, IDLE):
-                self._scene_manager.switch(self._scenes[IDLE.__name__.lower()])
+                self._scene_manager.switch(self._scenes[IDLE.name()])
             return
 
         stage = animal.current_stage.stage_name

--- a/src/mxbiflow/scene/scene.py
+++ b/src/mxbiflow/scene/scene.py
@@ -1,12 +1,18 @@
 from abc import ABC, abstractmethod
 from typing import ClassVar
 
+from inflection import underscore
 from pygame.event import Event
 from pygame.surface import Surface
 
 
 class Scene(ABC):
     level_table: ClassVar[dict[str, list[int]]] = {}
+
+    @classmethod
+    def name(cls) -> str:
+        """Return the canonical snake-case scene name."""
+        return underscore(cls.__name__)
 
     def __init__(self) -> None:
         self._running: bool = False

--- a/src/mxbiflow/scene/scene_manager.py
+++ b/src/mxbiflow/scene/scene_manager.py
@@ -25,7 +25,7 @@ class SceneManager:
             self._scenes.update(scene)
         else:
             for s in scene:
-                self._scenes[s.__name__.lower()] = s
+                self._scenes[s.name()] = s
 
     @property
     def scenes(self) -> dict[str, type[Scene]]:

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,0 +1,23 @@
+import unittest
+
+from mxbiflow.scene import Scene
+from mxbiflow.scene.idle.idle import IDLE
+
+
+class VocalizationDiscriminate(Scene):
+    pass
+
+
+class SceneTests(unittest.TestCase):
+    def test_name_converts_class_name_to_snake_case(self) -> None:
+        self.assertEqual(
+            VocalizationDiscriminate.name(),
+            "vocalization_discriminate",
+        )
+
+    def test_name_handles_uppercase_class_name(self) -> None:
+        self.assertEqual(IDLE.name(), "idle")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -31,11 +31,11 @@ class TargetStage(Scene):
 
 class SchedulerTests(unittest.TestCase):
     def test_unknown_animal_uses_configured_animal_stage(self) -> None:
-        animal_config = AnimalConfig(name="fallback", stage="targetstage")
+        animal_config = AnimalConfig(name="fallback", stage="target_stage")
         animal = Animal(
             config=animal_config,
-            current_stage_name="targetstage",
-            stages={"targetstage": StageState(stage_name="targetstage")},
+            current_stage_name="target_stage",
+            stages={"target_stage": StageState(stage_name="target_stage")},
         )
         session = Session(
             config=SessionConfig(
@@ -50,6 +50,7 @@ class SchedulerTests(unittest.TestCase):
         )
         scene_manager = SceneManager()
         scene_manager.register([TargetStage])
+        self.assertIs(scene_manager.scenes["target_stage"], TargetStage)
         scheduler = Scheduler(session, scene_manager)
 
         scheduler.handle_event(


### PR DESCRIPTION
## Summary
- add `Scene.name()` as the canonical snake-case scene identifier
- use the shared name across registration, scheduling, and session state
- cover standard and uppercase class names in tests

## Verification
- `uv run --frozen python -m unittest discover -s tests` (100 tests)
- `uv run --frozen pyright`
- `uvx ruff check .`