### PR TITLE
feat(gameloop): :sparkles: centralize keyboard shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ samba_mount/
 services/mount.service
 config/
 AGENTS.md
+.worktree/
 # Created by https://www.toptal.com/developers/gitignore/api/linux,windows,macos,python
 # Edit at https://www.toptal.com/developers/gitignore?templates=linux,windows,macos,python
 

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,22 @@
+# Keyboard Shortcuts
+
+This document lists the keyboard shortcuts supported by the MXBI game loop.
+All shortcuts are registered centrally in
+`src/mxbiflow/gameloop/shortcuts.py` via `register_default_shortcuts`.
+
+| Key | Action | Notes |
+| --- | --- | --- |
+| `Esc` | Quit the game | Stops the game loop and cleans up the session. |
+| `q` | Quit the game | Same as `Esc`. |
+| `c` | Capture a screenshot | Saved to the session screenshot directory. |
+| `0` – `5` | Simulate the RFID animal at the corresponding index entering | Index follows the configured animal map order; only effective with a mock detector. |
+| `l` | Simulate the current animal leaving | Only effective with a mock detector. |
+
+## Adding a new shortcut
+
+1. Add the binding in `register_default_shortcuts` with
+   `registry.register(key, description, handler)`.
+2. Document the key in the table above.
+3. Add a matching dispatch test in `tests/test_shortcuts.py`.
+
+Duplicate keys are rejected with `ValueError` at registration time.

--- a/src/mxbiflow/gameloop/__init__.py
+++ b/src/mxbiflow/gameloop/__init__.py
@@ -10,6 +10,7 @@ from .settlement import (
     settle_by_count,
     settle_by_rate,
 )
+from .shortcuts import ShortcutRegistry, register_default_shortcuts
 
 __all__ = [
     "EVT_DETECTOR",
@@ -22,6 +23,8 @@ __all__ = [
     "RateSettlementResult",
     "Scheduler",
     "SettlementAction",
+    "ShortcutRegistry",
+    "register_default_shortcuts",
     "settle_by_count",
     "settle_by_rate",
 ]

--- a/src/mxbiflow/gameloop/detector_bridge.py
+++ b/src/mxbiflow/gameloop/detector_bridge.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from queue import Empty, SimpleQueue
 
 import pygame
-from pygame import Event, event
+from pygame import event
 
 from mxbiflow.driver.detector import MockDetector
 from mxbiflow.driver.detector.detector import DetectionResult, Detector, DetectorEvent
@@ -81,25 +81,14 @@ class DetectorBridge:
             else:
                 self._detector.animal_present(animal_id)
 
+    def manual_emit_by_index(self, index: int) -> None:
+        """Simulate the animal at *index* in the animal map entering."""
+        rfid_key = self._rfid_key_at(index)
+        if rfid_key is not None:
+            self.manual_emit(rfid_key)
+
     def _rfid_key_at(self, index: int) -> str | None:
         keys = list(self._animals_map.keys())
         if index < len(keys):
             return keys[index]
         return None
-
-    def handle_event(self, event: Event) -> None:
-        if event.type == pygame.KEYDOWN:
-            key_map = {
-                pygame.K_0: 0,
-                pygame.K_1: 1,
-                pygame.K_2: 2,
-                pygame.K_3: 3,
-                pygame.K_4: 4,
-                pygame.K_5: 5,
-            }
-            if event.key in key_map:
-                rfid_key = self._rfid_key_at(key_map[event.key])
-                if rfid_key is not None:
-                    self.manual_emit(rfid_key)
-            elif event.key == pygame.K_l:
-                self.manual_emit()

--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -12,6 +12,7 @@ from ..scene import SceneManager
 from ..utils.logger import logger
 from .detector_bridge import DetectorBridge
 from .scheduler import Scheduler
+from .shortcuts import ShortcutRegistry, register_default_shortcuts
 
 
 class Game:
@@ -41,6 +42,14 @@ class Game:
 
         self._detector_binder = detector_bridge
         self._detector_binder.start()
+
+        self._shortcuts = ShortcutRegistry()
+        register_default_shortcuts(
+            self._shortcuts,
+            on_quit=self._request_quit,
+            on_capture=self._capture_screen,
+            detector_bridge=self._detector_binder,
+        )
 
         self._scheduler = Scheduler(self._session, self._scene_manager)
 
@@ -81,7 +90,6 @@ class Game:
                 self._handle_event(event)
                 self._scheduler.handle_event(event)
                 self._scene_manager.handle_event(event)
-                self._detector_binder.handle_event(event)
 
             self._scene_manager.update(dt)
             self._aplayer.update()
@@ -113,15 +121,10 @@ class Game:
                 pass
 
     def _handle_keyboard_event(self, event: Event) -> None:
-        match event.key:
-            case pygame.K_ESCAPE:
-                self._running = False
-            case pygame.K_q:
-                self._running = False
-            case pygame.K_c:
-                self._capture_screen()
-            case _:
-                pass
+        self._shortcuts.handle_event(event)
+
+    def _request_quit(self) -> None:
+        self._running = False
 
     def _capture_screen(self) -> None:
         screenshot_dir = self._session.absolute_screenshot_data_path

--- a/src/mxbiflow/gameloop/shortcuts.py
+++ b/src/mxbiflow/gameloop/shortcuts.py
@@ -1,0 +1,80 @@
+"""Centralized keyboard shortcut registration for the game loop."""
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Protocol
+
+import pygame
+from pygame import Event
+
+
+class ManualEmitter(Protocol):
+    """Minimal interface used by the detector shortcut handlers."""
+
+    def manual_emit(self, animal_id: str | None = None) -> None: ...
+
+    def manual_emit_by_index(self, index: int) -> None: ...
+
+
+@dataclass(frozen=True)
+class ShortcutBinding:
+    """A single registered shortcut binding."""
+
+    key: int
+    description: str
+    handler: Callable[[Event], None]
+
+
+class ShortcutRegistry:
+    """Registry mapping pygame keys to shortcut handlers."""
+
+    def __init__(self) -> None:
+        self._bindings: dict[int, ShortcutBinding] = {}
+
+    @property
+    def bindings(self) -> Mapping[int, ShortcutBinding]:
+        """Read-only view of the registered bindings keyed by pygame key."""
+        return self._bindings
+
+    def register(
+        self,
+        key: int,
+        description: str,
+        handler: Callable[[Event], None],
+    ) -> None:
+        """Register a shortcut for *key*, rejecting duplicate keys."""
+        if key in self._bindings:
+            raise ValueError(f"shortcut for key {key} is already registered")
+        self._bindings[key] = ShortcutBinding(key, description, handler)
+
+    def handle_event(self, event: Event) -> None:
+        """Dispatch a KEYDOWN event to its registered handler, if any."""
+        if event.type != pygame.KEYDOWN:
+            return
+        binding = self._bindings.get(event.key)
+        if binding is not None:
+            binding.handler(event)
+
+
+def register_default_shortcuts(
+    registry: ShortcutRegistry,
+    *,
+    on_quit: Callable[[], None],
+    on_capture: Callable[[], None],
+    detector_bridge: ManualEmitter,
+) -> None:
+    """Register the built-in game and detector shortcuts."""
+    registry.register(pygame.K_ESCAPE, "Quit the game", lambda _event: on_quit())
+    registry.register(pygame.K_q, "Quit the game", lambda _event: on_quit())
+    registry.register(pygame.K_c, "Capture a screenshot", lambda _event: on_capture())
+    for index in range(6):
+        registry.register(
+            pygame.K_0 + index,
+            f"Simulate RFID animal {index} entering",
+            lambda _event, index=index: detector_bridge.manual_emit_by_index(index),
+        )
+    registry.register(
+        pygame.K_l,
+        "Simulate RFID animal leaving",
+        lambda _event: detector_bridge.manual_emit(),
+    )

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,121 @@
+import unittest
+
+import pygame
+
+from mxbiflow.driver.detector.mock_detector import MockDetector
+from mxbiflow.gameloop.detector_bridge import DetectorBridge
+from mxbiflow.gameloop.shortcuts import ShortcutRegistry, register_default_shortcuts
+
+
+class ShortcutRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.registry = ShortcutRegistry()
+
+    @staticmethod
+    def _keydown(key: int) -> pygame.event.Event:
+        return pygame.event.Event(pygame.KEYDOWN, key=key)
+
+    def test_registered_key_dispatches_handler(self) -> None:
+        handled: list[pygame.event.Event] = []
+        self.registry.register(pygame.K_ESCAPE, "Quit the game", handled.append)
+        event = self._keydown(pygame.K_ESCAPE)
+
+        self.registry.handle_event(event)
+
+        self.assertEqual(handled, [event])
+
+    def test_unknown_key_is_ignored(self) -> None:
+        handled: list[pygame.event.Event] = []
+        self.registry.register(pygame.K_ESCAPE, "Quit the game", handled.append)
+
+        self.registry.handle_event(self._keydown(pygame.K_a))
+
+        self.assertEqual(handled, [])
+
+    def test_non_keydown_events_are_ignored(self) -> None:
+        handled: list[pygame.event.Event] = []
+        self.registry.register(pygame.K_ESCAPE, "Quit the game", handled.append)
+        event = pygame.event.Event(pygame.KEYUP, key=pygame.K_ESCAPE)
+
+        self.registry.handle_event(event)
+
+        self.assertEqual(handled, [])
+
+    def test_duplicate_key_raises_value_error(self) -> None:
+        self.registry.register(pygame.K_ESCAPE, "Quit the game", lambda _event: None)
+
+        with self.assertRaises(ValueError):
+            self.registry.register(
+                pygame.K_ESCAPE, "Quit the game again", lambda _event: None
+            )
+
+
+class RegisterDefaultShortcutsTests(unittest.TestCase):
+    def test_builtin_shortcuts_dispatch_to_handlers(self) -> None:
+        registry = ShortcutRegistry()
+        quits: list[bool] = []
+        captures: list[bool] = []
+        detector = MockDetector()
+        bridge = DetectorBridge(detector, {"rfid-a": "animal-a", "rfid-b": "animal-b"})
+
+        register_default_shortcuts(
+            registry,
+            on_quit=lambda: quits.append(True),
+            on_capture=lambda: captures.append(True),
+            detector_bridge=bridge,
+        )
+
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE))
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_q))
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_c))
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_0))
+        self.assertEqual(detector.current_animal, "rfid-a")
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_1))
+        self.assertEqual(detector.current_animal, "rfid-b")
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_l))
+
+        self.assertEqual(quits, [True, True])
+        self.assertEqual(captures, [True])
+        self.assertIsNone(detector.current_animal)
+
+    def test_default_bindings_are_exposed(self) -> None:
+        registry = ShortcutRegistry()
+        register_default_shortcuts(
+            registry,
+            on_quit=lambda: None,
+            on_capture=lambda: None,
+            detector_bridge=DetectorBridge(MockDetector(), {}),
+        )
+
+        expected_keys = {
+            pygame.K_ESCAPE,
+            pygame.K_q,
+            pygame.K_c,
+            *range(pygame.K_0, pygame.K_0 + 6),
+            pygame.K_l,
+        }
+        self.assertEqual(set(registry.bindings), expected_keys)
+
+
+class DetectorBridgeManualEmitTests(unittest.TestCase):
+    def test_manual_emit_by_index_resolves_animal_map_order(self) -> None:
+        detector = MockDetector()
+        bridge = DetectorBridge(detector, {"rfid-a": "animal-a", "rfid-b": "animal-b"})
+
+        bridge.manual_emit_by_index(0)
+        self.assertEqual(detector.current_animal, "rfid-a")
+
+        bridge.manual_emit_by_index(1)
+        self.assertEqual(detector.current_animal, "rfid-b")
+
+    def test_manual_emit_by_index_out_of_range_is_noop(self) -> None:
+        detector = MockDetector()
+        bridge = DetectorBridge(detector, {"rfid-a": "animal-a"})
+
+        bridge.manual_emit_by_index(5)
+
+        self.assertIsNone(detector.current_animal)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Centralize pygame and detector keyboard shortcuts into a single registry.

- Add `ShortcutRegistry` and `register_default_shortcuts` in `src/mxbiflow/gameloop/shortcuts.py` covering Esc/q quit, c screenshot, 0-5 mock RFID animal enter, and l mock animal leave.
- Route `Game` keyboard events through the registry; remove `DetectorBridge.handle_event` and add `manual_emit_by_index`.
- Add `docs/shortcuts.md` and unit tests.

Verified: 108 unit tests pass, ruff clean.