### PR TITLE
feat(gameloop): :sparkles: add manual level and stage navigation shortcuts

### DIFF
--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -11,6 +11,10 @@ All shortcuts are registered centrally in
 | `c` | Capture a screenshot | Saved to the session screenshot directory. |
 | `0` – `5` | Simulate the RFID animal at the corresponding index entering | Index follows the configured animal map order; only effective with a mock detector. |
 | `l` | Simulate the current animal leaving | Only effective with a mock detector. |
+| `[` | Level down | Manually decreases the current animal's current stage level; requires a current animal. |
+| `]` | Level up | Manually increases the current animal's current stage level; requires a current animal. |
+| `,` | Previous stage | Moves to the previous stage in the current animal's configured `stage_order` list; no-op when unavailable. |
+| `.` | Next stage | Moves to the next stage in the current animal's configured `stage_order` list; no-op when unavailable. |
 
 ## Adding a new shortcut
 

--- a/src/mxbiflow/gameloop/game.py
+++ b/src/mxbiflow/gameloop/game.py
@@ -43,15 +43,16 @@ class Game:
         self._detector_binder = detector_bridge
         self._detector_binder.start()
 
+        self._scheduler = Scheduler(self._session, self._scene_manager)
+
         self._shortcuts = ShortcutRegistry()
         register_default_shortcuts(
             self._shortcuts,
             on_quit=self._request_quit,
             on_capture=self._capture_screen,
             detector_bridge=self._detector_binder,
+            manual_control=self._scheduler,
         )
-
-        self._scheduler = Scheduler(self._session, self._scene_manager)
 
         self._mxbiflow = MXBIFlow(self._session, self._mxbi)
 

--- a/src/mxbiflow/gameloop/scheduler.py
+++ b/src/mxbiflow/gameloop/scheduler.py
@@ -35,12 +35,42 @@ class Scheduler:
         self._session.clear_current_animal()
         self._mark_refresh()
 
-    def _set_next_stage(self, stage: str) -> None:
+    def level_up(self) -> None:
+        """Manually increase the current animal's current stage level."""
         if self._session.current_animal is None:
             return
+        self._session.level_up()
+        self._mark_refresh()
 
-        self._session.set_current_stage(stage)
-        self._need_refresh = True
+    def level_down(self) -> None:
+        """Manually decrease the current animal's current stage level."""
+        animal = self._session.current_animal
+        if animal is None or animal.current_stage.level == 0:
+            return
+        self._session.level_down()
+        self._mark_refresh()
+
+    def next_stage(self) -> None:
+        """Manually move the current animal to the next configured stage."""
+        target = self._session.next_stage
+        if target is None:
+            return
+        if target not in self._scenes:
+            logger.debug("manual stage target not registered: %s", target)
+            return
+        self._session.go_next_stage()
+        self._mark_refresh()
+
+    def prev_stage(self) -> None:
+        """Manually move the current animal to the previous configured stage."""
+        target = self._session.prev_stage
+        if target is None:
+            return
+        if target not in self._scenes:
+            logger.debug("manual stage target not registered: %s", target)
+            return
+        self._session.go_prev_stage()
+        self._mark_refresh()
 
     def _handle_fault_event(self) -> None:
         fallback = self._scene_manager.fault_fallback

--- a/src/mxbiflow/gameloop/shortcuts.py
+++ b/src/mxbiflow/gameloop/shortcuts.py
@@ -16,6 +16,18 @@ class ManualEmitter(Protocol):
     def manual_emit_by_index(self, index: int) -> None: ...
 
 
+class ManualControl(Protocol):
+    """Minimal interface used by the manual level/stage shortcut handlers."""
+
+    def level_up(self) -> None: ...
+
+    def level_down(self) -> None: ...
+
+    def next_stage(self) -> None: ...
+
+    def prev_stage(self) -> None: ...
+
+
 @dataclass(frozen=True)
 class ShortcutBinding:
     """A single registered shortcut binding."""
@@ -62,8 +74,9 @@ def register_default_shortcuts(
     on_quit: Callable[[], None],
     on_capture: Callable[[], None],
     detector_bridge: ManualEmitter,
+    manual_control: ManualControl,
 ) -> None:
-    """Register the built-in game and detector shortcuts."""
+    """Register the built-in game, detector, and manual control shortcuts."""
     registry.register(pygame.K_ESCAPE, "Quit the game", lambda _event: on_quit())
     registry.register(pygame.K_q, "Quit the game", lambda _event: on_quit())
     registry.register(pygame.K_c, "Capture a screenshot", lambda _event: on_capture())
@@ -77,4 +90,24 @@ def register_default_shortcuts(
         pygame.K_l,
         "Simulate RFID animal leaving",
         lambda _event: detector_bridge.manual_emit(),
+    )
+    registry.register(
+        pygame.K_LEFTBRACKET,
+        "Level down",
+        lambda _event: manual_control.level_down(),
+    )
+    registry.register(
+        pygame.K_RIGHTBRACKET,
+        "Level up",
+        lambda _event: manual_control.level_up(),
+    )
+    registry.register(
+        pygame.K_COMMA,
+        "Previous stage",
+        lambda _event: manual_control.prev_stage(),
+    )
+    registry.register(
+        pygame.K_PERIOD,
+        "Next stage",
+        lambda _event: manual_control.next_stage(),
     )

--- a/src/mxbiflow/models/animal.py
+++ b/src/mxbiflow/models/animal.py
@@ -40,6 +40,8 @@ class AnimalConfig(BaseModel):
     name: str = "mock"
     stage: str = "idle"
     level: int = Field(default=0, ge=0)
+    # Ordered stage names for manual next/prev navigation; empty disables it.
+    stage_order: tuple[str, ...] = ()
 
 
 class AnimalBaseInfo(BaseModel):

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -408,6 +408,49 @@ class Session(BaseModel):
         animal.stages.setdefault(stage.stage_name, stage)
         self.checkpoint()
 
+    @property
+    def next_stage(self) -> str | None:
+        """Return the next stage name for the current animal, if any."""
+        return self._adjacent_stage(1)
+
+    @property
+    def prev_stage(self) -> str | None:
+        """Return the previous stage name for the current animal, if any."""
+        return self._adjacent_stage(-1)
+
+    def go_next_stage(self) -> str | None:
+        """Move the current animal to the next configured stage, if any."""
+        return self._go_to_adjacent_stage(1)
+
+    def go_prev_stage(self) -> str | None:
+        """Move the current animal to the previous configured stage, if any."""
+        return self._go_to_adjacent_stage(-1)
+
+    def _adjacent_stage(self, delta: int) -> str | None:
+        animal = self.current_animal
+        if animal is None:
+            return None
+
+        stage_order = animal.config.stage_order
+        if not stage_order:
+            return None
+        try:
+            index = stage_order.index(animal.current_stage_name)
+        except ValueError:
+            return None
+
+        target_index = index + delta
+        if target_index < 0 or target_index >= len(stage_order):
+            return None
+        return stage_order[target_index]
+
+    def _go_to_adjacent_stage(self, delta: int) -> str | None:
+        target = self._adjacent_stage(delta)
+        if target is None:
+            return None
+        self.set_current_stage(target)
+        return target
+
     def add_trial(self) -> None:
         animal = self.require_current_animal()
         animal_session = animal.current_animal_session

--- a/src/mxbiflow/ui/components/animal.py
+++ b/src/mxbiflow/ui/components/animal.py
@@ -29,6 +29,7 @@ class AnimalCard(CardFrame):
         self.customContextMenuRequested.connect(self._on_context_menu)
 
         self._stage_level_tables = stage_level_tables
+        self._stage_order: tuple[str, ...] = ()
 
         items = list(animals.items())
         self._animal_ids = [animal_id for animal_id, _name in items]
@@ -105,6 +106,7 @@ class AnimalCard(CardFrame):
         menu.exec(self.mapToGlobal(pos))
 
     def load_config(self, config: AnimalConfig) -> None:
+        self._stage_order = config.stage_order
         self.combo_animal_name.setCurrentText(config.name)
         self.combo_stage.setCurrentText(config.stage)
         self.combo_level.setCurrentText(str(config.level))
@@ -118,4 +120,5 @@ class AnimalCard(CardFrame):
             level=int(self.combo_level.currentText())
             if self.combo_level.currentText()
             else 0,
+            stage_order=self._stage_order,
         )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -29,6 +29,31 @@ class TargetStage(Scene):
         pass
 
 
+class StageA(Scene):
+    def start(self) -> None:
+        self._running = True
+
+    def quit(self) -> None:
+        self._running = False
+
+    def handle_event(self, event: Event) -> None:
+        pass
+
+    def update(self, dt_s: float) -> None:
+        pass
+
+    def draw(self, screen: Surface) -> None:
+        pass
+
+
+class StageB(StageA):
+    pass
+
+
+class StageC(StageA):
+    pass
+
+
 class SchedulerTests(unittest.TestCase):
     def test_unknown_animal_uses_configured_animal_stage(self) -> None:
         animal_config = AnimalConfig(name="fallback", stage="target_stage")
@@ -67,6 +92,126 @@ class SchedulerTests(unittest.TestCase):
 
         self.assertIs(session.current_animal, animal)
         self.assertIsInstance(scene_manager.current, TargetStage)
+
+
+class ManualControlTests(unittest.TestCase):
+    @staticmethod
+    def _make_session(
+        *,
+        stage: str = "stage_a",
+        level: int = 0,
+        stage_order: tuple[str, ...] = (),
+    ) -> tuple[Session, Animal]:
+        animal_config = AnimalConfig(
+            name="animal-a",
+            stage=stage,
+            level=level,
+            stage_order=stage_order,
+        )
+        animal = Animal(
+            config=animal_config,
+            current_stage_name=stage,
+            stages={stage: StageState(stage_name=stage, level=level)},
+        )
+        session = Session(
+            config=SessionConfig(
+                unknown_animal_as=animal_config.name,
+                animals=(animal_config,),
+            ),
+            mxbi_config=MXBIModel(
+                backup_source_root_id="source",
+                backup_destination_root_id="destination",
+            ),
+            state=SessionState(animals={animal.name: animal}),
+        )
+        return session, animal
+
+    @staticmethod
+    def _make_scheduler(session: Session) -> tuple[Scheduler, SceneManager]:
+        scene_manager = SceneManager()
+        scene_manager.register([StageA, StageB, StageC])
+        return Scheduler(session, scene_manager), scene_manager
+
+    def test_manual_level_up_increases_level_and_refreshes_scene(self) -> None:
+        session, animal = self._make_session(level=2)
+        scheduler, scene_manager = self._make_scheduler(session)
+        session.set_current_animal("animal-a")
+
+        scheduler.level_up()
+
+        self.assertEqual(animal.current_stage.level, 3)
+        scheduler.update()
+        scene_manager.apply_pending()
+        self.assertIsInstance(scene_manager.current, StageA)
+
+    def test_manual_level_down_decreases_level(self) -> None:
+        session, animal = self._make_session(level=2)
+        scheduler, _scene_manager = self._make_scheduler(session)
+        session.set_current_animal("animal-a")
+
+        scheduler.level_down()
+
+        self.assertEqual(animal.current_stage.level, 1)
+
+    def test_manual_level_down_at_zero_is_noop(self) -> None:
+        session, animal = self._make_session(level=0)
+        scheduler, _scene_manager = self._make_scheduler(session)
+        session.set_current_animal("animal-a")
+
+        scheduler.level_down()
+
+        self.assertEqual(animal.current_stage.level, 0)
+
+    def test_manual_controls_are_noop_without_current_animal(self) -> None:
+        session, animal = self._make_session(level=2)
+        scheduler, _scene_manager = self._make_scheduler(session)
+
+        scheduler.level_up()
+        scheduler.level_down()
+        scheduler.next_stage()
+        scheduler.prev_stage()
+
+        self.assertEqual(animal.current_stage.level, 2)
+        self.assertEqual(animal.current_stage_name, "stage_a")
+
+    def test_manual_next_stage_moves_to_next_configured_stage(self) -> None:
+        session, _animal = self._make_session(
+            stage="stage_a",
+            stage_order=("stage_a", "stage_b", "stage_c"),
+        )
+        scheduler, scene_manager = self._make_scheduler(session)
+        session.set_current_animal("animal-a")
+
+        scheduler.next_stage()
+
+        self.assertEqual(session.current_animal.current_stage_name, "stage_b")
+        scheduler.update()
+        scene_manager.apply_pending()
+        self.assertIsInstance(scene_manager.current, StageB)
+
+    def test_manual_prev_stage_moves_to_previous_configured_stage(self) -> None:
+        session, _animal = self._make_session(
+            stage="stage_b",
+            stage_order=("stage_a", "stage_b", "stage_c"),
+        )
+        scheduler, _scene_manager = self._make_scheduler(session)
+        session.set_current_animal("animal-a")
+
+        scheduler.prev_stage()
+
+        self.assertEqual(session.current_animal.current_stage_name, "stage_a")
+
+    def test_manual_stage_navigation_noop_when_target_not_registered(self) -> None:
+        session, _animal = self._make_session(
+            stage="stage_a",
+            stage_order=("stage_a", "stage_unregistered"),
+        )
+        scheduler, _scene_manager = self._make_scheduler(session)
+        session.set_current_animal("animal-a")
+
+        scheduler.next_stage()
+
+        self.assertEqual(session.current_animal.current_stage_name, "stage_a")
 
 
 if __name__ == "__main__":

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -175,6 +175,18 @@ class SessionModelTests(unittest.TestCase):
                 }
             )
 
+    def test_animal_config_stage_order_roundtrip(self) -> None:
+        config = AnimalConfig(
+            name="animal-1",
+            stage="stage_a",
+            stage_order=("stage_a", "stage_b"),
+        )
+
+        parsed = AnimalConfig.model_validate_json(config.model_dump_json())
+
+        self.assertEqual(parsed.stage_order, ("stage_a", "stage_b"))
+        self.assertEqual(AnimalConfig().stage_order, ())
+
     def test_bootstrap_reuses_animal_config(self) -> None:
         animal_config = AnimalConfig(
             rfid_id="rfid-1",
@@ -277,6 +289,7 @@ class SessionModelTests(unittest.TestCase):
                 "name": "animal-1",
                 "stage": "vocalization_discriminate",
                 "level": 2,
+                "stage_order": [],
             },
         )
         self.assertEqual(animal["rfid_id"], "rfid-1")
@@ -545,6 +558,121 @@ class SessionModelTests(unittest.TestCase):
             ),
             ExampleContext(value=4),
         )
+
+
+class StageNavigationTests(unittest.TestCase):
+    @staticmethod
+    def _make_session(
+        *,
+        stage: str = "stage_a",
+        stage_order: tuple[str, ...] = (),
+    ) -> tuple[Session, Animal]:
+        animal_config = AnimalConfig(
+            name="animal-1",
+            stage=stage,
+            stage_order=stage_order,
+        )
+        animal = Animal(
+            config=animal_config,
+            current_stage_name=stage,
+            stages={stage: StageState(stage_name=stage)},
+        )
+        session = Session(
+            config=SessionConfig(
+                unknown_animal_as=animal_config.name,
+                animals=(animal_config,),
+            ),
+            mxbi_config=MXBIModel(
+                backup_source_root_id="source",
+                backup_destination_root_id="destination",
+            ),
+            state=SessionState(animals={animal.name: animal}),
+        )
+        return session, animal
+
+    def test_adjacent_stages_are_none_without_current_animal(self) -> None:
+        session, _animal = self._make_session(
+            stage_order=("stage_a", "stage_b"),
+        )
+
+        self.assertIsNone(session.next_stage)
+        self.assertIsNone(session.prev_stage)
+        self.assertIsNone(session.go_next_stage())
+        self.assertIsNone(session.go_prev_stage())
+
+    def test_adjacent_stages_are_none_when_stage_order_is_empty(self) -> None:
+        session, animal = self._make_session()
+        session.set_current_animal("animal-1")
+
+        self.assertIsNone(session.next_stage)
+        self.assertIsNone(session.prev_stage)
+        self.assertIsNone(session.go_next_stage())
+        self.assertIsNone(session.go_prev_stage())
+        self.assertEqual(animal.current_stage_name, "stage_a")
+
+    def test_adjacent_stages_are_none_when_current_stage_not_in_order(self) -> None:
+        session, animal = self._make_session(
+            stage="other",
+            stage_order=("stage_a", "stage_b"),
+        )
+        session.set_current_animal("animal-1")
+
+        self.assertIsNone(session.next_stage)
+        self.assertIsNone(session.prev_stage)
+        self.assertIsNone(session.go_next_stage())
+        self.assertIsNone(session.go_prev_stage())
+        self.assertEqual(animal.current_stage_name, "other")
+
+    def test_adjacent_stages_clamp_at_ends(self) -> None:
+        first_session, first_animal = self._make_session(
+            stage="stage_a",
+            stage_order=("stage_a", "stage_b", "stage_c"),
+        )
+        first_session.set_current_animal("animal-1")
+
+        self.assertEqual(first_session.next_stage, "stage_b")
+        self.assertIsNone(first_session.prev_stage)
+        self.assertIsNone(first_session.go_prev_stage())
+        self.assertEqual(first_animal.current_stage_name, "stage_a")
+
+        last_session, last_animal = self._make_session(
+            stage="stage_c",
+            stage_order=("stage_a", "stage_b", "stage_c"),
+        )
+        last_session.set_current_animal("animal-1")
+
+        self.assertEqual(last_session.prev_stage, "stage_b")
+        self.assertIsNone(last_session.next_stage)
+        self.assertIsNone(last_session.go_next_stage())
+        self.assertEqual(last_animal.current_stage_name, "stage_c")
+
+    def test_go_next_stage_moves_to_next_configured_stage(self) -> None:
+        session, animal = self._make_session(
+            stage="stage_a",
+            stage_order=("stage_a", "stage_b", "stage_c"),
+        )
+        session.set_current_animal("animal-1")
+
+        self.assertEqual(session.next_stage, "stage_b")
+        result = session.go_next_stage()
+
+        self.assertEqual(result, "stage_b")
+        self.assertEqual(animal.current_stage_name, "stage_b")
+        self.assertIn("stage_b", animal.stages)
+
+    def test_go_prev_stage_moves_to_previous_configured_stage(self) -> None:
+        session, animal = self._make_session(
+            stage="stage_b",
+            stage_order=("stage_a", "stage_b", "stage_c"),
+        )
+        session.set_current_animal("animal-1")
+
+        self.assertEqual(session.prev_stage, "stage_a")
+        result = session.go_prev_stage()
+
+        self.assertEqual(result, "stage_a")
+        self.assertEqual(animal.current_stage_name, "stage_a")
+        self.assertIn("stage_a", animal.stages)
 
 
 if __name__ == "__main__":

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -7,6 +7,23 @@ from mxbiflow.gameloop.detector_bridge import DetectorBridge
 from mxbiflow.gameloop.shortcuts import ShortcutRegistry, register_default_shortcuts
 
 
+class FakeManualControl:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def level_up(self) -> None:
+        self.calls.append("level_up")
+
+    def level_down(self) -> None:
+        self.calls.append("level_down")
+
+    def next_stage(self) -> None:
+        self.calls.append("next_stage")
+
+    def prev_stage(self) -> None:
+        self.calls.append("prev_stage")
+
+
 class ShortcutRegistryTests(unittest.TestCase):
     def setUp(self) -> None:
         self.registry = ShortcutRegistry()
@@ -55,6 +72,7 @@ class RegisterDefaultShortcutsTests(unittest.TestCase):
         registry = ShortcutRegistry()
         quits: list[bool] = []
         captures: list[bool] = []
+        manual = FakeManualControl()
         detector = MockDetector()
         bridge = DetectorBridge(detector, {"rfid-a": "animal-a", "rfid-b": "animal-b"})
 
@@ -63,6 +81,7 @@ class RegisterDefaultShortcutsTests(unittest.TestCase):
             on_quit=lambda: quits.append(True),
             on_capture=lambda: captures.append(True),
             detector_bridge=bridge,
+            manual_control=manual,
         )
 
         registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_ESCAPE))
@@ -73,10 +92,22 @@ class RegisterDefaultShortcutsTests(unittest.TestCase):
         registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_1))
         self.assertEqual(detector.current_animal, "rfid-b")
         registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_l))
+        registry.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_LEFTBRACKET)
+        )
+        registry.handle_event(
+            pygame.event.Event(pygame.KEYDOWN, key=pygame.K_RIGHTBRACKET)
+        )
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_COMMA))
+        registry.handle_event(pygame.event.Event(pygame.KEYDOWN, key=pygame.K_PERIOD))
 
         self.assertEqual(quits, [True, True])
         self.assertEqual(captures, [True])
         self.assertIsNone(detector.current_animal)
+        self.assertEqual(
+            manual.calls,
+            ["level_down", "level_up", "prev_stage", "next_stage"],
+        )
 
     def test_default_bindings_are_exposed(self) -> None:
         registry = ShortcutRegistry()
@@ -85,6 +116,7 @@ class RegisterDefaultShortcutsTests(unittest.TestCase):
             on_quit=lambda: None,
             on_capture=lambda: None,
             detector_bridge=DetectorBridge(MockDetector(), {}),
+            manual_control=FakeManualControl(),
         )
 
         expected_keys = {
@@ -93,6 +125,10 @@ class RegisterDefaultShortcutsTests(unittest.TestCase):
             pygame.K_c,
             *range(pygame.K_0, pygame.K_0 + 6),
             pygame.K_l,
+            pygame.K_LEFTBRACKET,
+            pygame.K_RIGHTBRACKET,
+            pygame.K_COMMA,
+            pygame.K_PERIOD,
         }
         self.assertEqual(set(registry.bindings), expected_keys)
 


### PR DESCRIPTION
Add manual keyboard shortcuts for level and stage navigation in the game loop.

Changes:
- Add per-animal `stage_order` config field to `AnimalConfig` for manual stage navigation
- Expose `Session.next_stage`/`prev_stage` properties and `go_next_stage`/`go_prev_stage` methods (no-op when unavailable)
- Bind `[`/`]` to level down/up and `,`/`.` to stage prev/next via `ManualControl` in `register_default_shortcuts`
- Keep `stage_order` out of the wizard UI while preserving it across wizard saves
- Update shortcuts documentation and tests

Verification:
- `unittest discover -s tests`: 122 tests passed
- `ruff check`: all checks passed