### PR TITLE
ci: :construction_worker: add workflow_dispatch trigger to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Changes
- Add `workflow_dispatch` trigger to `publish.yml`

## Why
GitHub's Aug 6 Actions incident (qcvjkzcs7j74) dropped push events for #133; the workflow trigger registration was never restored. Touching the workflow file forces GitHub to re-register the trigger, and `workflow_dispatch` enables manual runs going forward.

## Verification
- CI checks run on this PR before merge
