### PR TITLE
fix(mxbi): :bug: allow default MXBI config without backup root ids

### DIFF
--- a/src/mxbiflow/driver/mxbi/factory.py
+++ b/src/mxbiflow/driver/mxbi/factory.py
@@ -24,8 +24,8 @@ from .mxbi import MXBI
 class MXBIModel(BaseModel):
     mxbi_id: str = Field(default="debug")
     screen_size: tuple[int, int] = Field(default=(1024, 600))
-    backup_source_root_id: str
-    backup_destination_root_id: str
+    backup_source_root_id: str = Field(default="")
+    backup_destination_root_id: str = Field(default="")
     rewarders: list[RewarderModel] = Field(default_factory=list)
     detectors: list[DetectorModel] = Field(default_factory=list)
 

--- a/tests/test_baseconfig_ui.py
+++ b/tests/test_baseconfig_ui.py
@@ -6,7 +6,6 @@ from unittest.mock import Mock, patch
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
-from pydantic import ValidationError
 from PySide6.QtCore import Qt
 from PySide6.QtTest import QTest
 from PySide6.QtWidgets import QApplication, QLabel
@@ -95,9 +94,22 @@ class BaseConfigTests(unittest.TestCase):
         self.assertEqual(saved.backup_destination_root_id, "updated-destination")
         panel.close()
 
-    def test_backup_root_ids_are_required(self) -> None:
-        with self.assertRaises(ValidationError):
-            MXBIModel.model_validate({})
+    def test_backup_root_ids_default_to_empty(self) -> None:
+        model = MXBIModel()
+        self.assertEqual(model.backup_source_root_id, "")
+        self.assertEqual(model.backup_destination_root_id, "")
+
+    def test_missing_mxbi_config_creates_default(self) -> None:
+        # Regression: on a fresh machine without config/mxbi.json, the
+        # wizard must be able to generate a default config instead of
+        # crashing on required fields.
+        panel = MXBIPanel()
+        config_path = get_mxbi_config_path()
+        self.assertTrue(config_path.is_file())
+        saved = MXBIModel.model_validate_json(config_path.read_text(encoding="utf-8"))
+        self.assertEqual(saved.backup_source_root_id, "")
+        self.assertEqual(saved.backup_destination_root_id, "")
+        panel.close()
 
     def test_legacy_mxbis_option_is_ignored_and_not_exported(self) -> None:
         database = MXBIDatabase.model_validate(


### PR DESCRIPTION
## What

`MXBIModel.backup_source_root_id` and `backup_destination_root_id` were required fields without defaults. On a fresh machine with no `config/mxbi.json`, `ConfigStore` falls back to generating a default config via `MXBIModel()`, which failed pydantic validation and crashed the setup wizard.

## Changes

- Default both fields to `""` so a default config can be generated; real values are still filled in via the MXBI wizard.
- Replaced the required-field test with a default-value test and a regression test covering the missing-config bootstrap path.

## Verification

- mxbiflow: 123 tests pass (incl. new regression test)
- 2ac-vocalization-discriminate: 275 tests pass
- ruff format/check clean; pyright no new errors