### PR TITLE
feat(detector): ✨ add configurable beam-break filtering

### DIFF
--- a/src/mxbiflow/driver/detector/__init__.py
+++ b/src/mxbiflow/driver/detector/__init__.py
@@ -65,6 +65,8 @@ class FusionContinuousDetectorModel(BaseModel):
 
     poll_interval: float = 10.0
     rfid_timeout: float = 0.05
+    beam_break_filter_enabled: bool = False
+    beam_break_filter_duration: float = Field(default=0.2, gt=0)
 
     @property
     def device_type(self) -> str:

--- a/src/mxbiflow/driver/detector/fusion_continuous_detector.py
+++ b/src/mxbiflow/driver/detector/fusion_continuous_detector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from enum import Enum, auto
 from threading import Event, Lock, Thread
-from time import sleep, time
+from time import monotonic, sleep, time
 from typing import NamedTuple
 
 from mxbiflow.driver.peripheral.beam_break_sensor.beam_break_sensor import (
@@ -77,7 +77,8 @@ class FusionContinuousDetector:
       ``UNKNOWN_ANIMAL_ENTERED`` with ``animal_id=None`` and ``error=True``
       (unknown animal).
     * **Falling edge** (beam restored — animal leaves): emit ``ANIMAL_LEFT``
-      immediately — no recent RFID result is required.
+      after the optional beam-break filter confirms a stable clear state. No
+      recent RFID result is required.
     """
 
     # ---- construction ----------------------------------------------------
@@ -88,11 +89,18 @@ class FusionContinuousDetector:
         beam_break_sensor: BeamBreakSensor,
         poll_interval: float = _POLL_INTERVAL_S,
         rfid_timeout: float = _RFID_TIMEOUT_S,
+        beam_break_filter_enabled: bool = False,
+        beam_break_filter_duration: float = 0.2,
     ) -> None:
+        if beam_break_filter_duration <= 0:
+            raise ValueError("beam_break_filter_duration must be greater than 0")
+
         self._rfid_reader = rfid_reader
         self._beam_break_sensor = beam_break_sensor
         self._poll_interval = poll_interval
         self._rfid_timeout = rfid_timeout
+        self._beam_break_filter_enabled = beam_break_filter_enabled
+        self._beam_break_filter_duration = beam_break_filter_duration
 
         # Event callbacks: DetectorEvent -> list of subscribers
         self._callbacks: dict[
@@ -102,6 +110,7 @@ class FusionContinuousDetector:
         # State-machine bookkeeping
         self._state: _State = _State.IDLE
         self._prev_beam: bool = False
+        self._beam_clear_since: float | None = None
         self._edge_time: float = 0.0
         self._last_tag: RFIDTag | None = None
         self._current_animal: str | None = None
@@ -186,7 +195,7 @@ class FusionContinuousDetector:
             events: list[_Event] = []
 
             # 1. Edge detection (beam break sensor)
-            edge = self._detect_edge()
+            edge = self._detect_edge(monotonic())
             if edge is not None:
                 events.append(edge)
 
@@ -211,18 +220,34 @@ class FusionContinuousDetector:
 
     # ---- internal: sensor helpers ----------------------------------------
 
-    def _detect_edge(self) -> _Event | None:
+    def _detect_edge(self, now: float) -> _Event | None:
         """Read beam sensor and return a rising / falling edge or *None*."""
         current = self._beam_break_sensor.read()
-        edge: _Event | None = None
 
-        if current and not self._prev_beam:
-            edge = _Event.RISING_EDGE
-        elif not current and self._prev_beam:
-            edge = _Event.FALLING_EDGE
+        if current:
+            self._beam_clear_since = None
+            if not self._prev_beam:
+                self._prev_beam = True
+                return _Event.RISING_EDGE
+            return None
 
-        self._prev_beam = current
-        return edge
+        if not self._prev_beam:
+            return None
+
+        if not self._beam_break_filter_enabled:
+            self._prev_beam = False
+            return _Event.FALLING_EDGE
+
+        if self._beam_clear_since is None:
+            self._beam_clear_since = now
+            return None
+
+        if now - self._beam_clear_since < self._beam_break_filter_duration:
+            return None
+
+        self._prev_beam = False
+        self._beam_clear_since = None
+        return _Event.FALLING_EDGE
 
     def _try_read_rfid(self, now: float) -> _Event | None:
         """Read RFID on-demand and return ``RFID_READ`` if a valid tag is available.

--- a/src/mxbiflow/driver/mxbi/factory.py
+++ b/src/mxbiflow/driver/mxbi/factory.py
@@ -93,6 +93,8 @@ def _make_detector(config: DetectorModel) -> Detector:
                 sensor,
                 poll_interval=config.poll_interval,
                 rfid_timeout=config.rfid_timeout,
+                beam_break_filter_enabled=config.beam_break_filter_enabled,
+                beam_break_filter_duration=config.beam_break_filter_duration,
             )
 
         case _:

--- a/src/mxbiflow/ui/components/device_card/detector/fusion_detector.py
+++ b/src/mxbiflow/ui/components/device_card/detector/fusion_detector.py
@@ -1,4 +1,12 @@
-from PySide6.QtWidgets import QComboBox, QLabel, QLineEdit
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QGridLayout,
+    QLabel,
+    QLineEdit,
+    QWidget,
+)
 
 from mxbiflow.driver.detector import FusionContinuousDetectorModel
 
@@ -8,35 +16,83 @@ from ..device_card import DeviceCard
 
 class FusionDetectorCard(DeviceCard[FusionContinuousDetectorModel]):
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(mount_base_fields=False)
 
         self.set_title("Fusion Detector")
+        self.setMinimumWidth(400)
 
-        label_pin = QLabel("Beam Break Pin")
+        self.checkbox_enabled.setText("Enabled")
+        self.line_device_id.setMaximumWidth(64)
+
         self._line_pin = QLineEdit()
         self._line_pin.setPlaceholderText("Pin Number")
-        self.layout_config.addRow(label_pin, self._line_pin)
+        self._line_pin.setMaximumWidth(64)
 
-        label_port = QLabel("Port")
         self._combo_port = QComboBox()
         self._combo_port.addItems(get_all_ports())
-        self.layout_config.addRow(label_port, self._combo_port)
 
-        label_baudrate = QLabel("Baudrate")
         self._combo_baudrate = QComboBox()
         for text, value in get_baudrates():
             self._combo_baudrate.addItem(text, value)
-        self.layout_config.addRow(label_baudrate, self._combo_baudrate)
+        self._combo_baudrate.setMaximumWidth(112)
 
-        label_poll_interval = QLabel("Poll Interval")
         self._line_poll_interval = QLineEdit()
         self._line_poll_interval.setPlaceholderText("Poll Interval (s)")
-        self.layout_config.addRow(label_poll_interval, self._line_poll_interval)
+        self._line_poll_interval.setMaximumWidth(72)
 
-        label_rfid_timeout = QLabel("RFID Timeout")
         self._line_rfid_timeout = QLineEdit()
         self._line_rfid_timeout.setPlaceholderText("RFID Timeout (s)")
-        self.layout_config.addRow(label_rfid_timeout, self._line_rfid_timeout)
+        self._line_rfid_timeout.setMaximumWidth(72)
+
+        self._checkbox_leave_filter = QCheckBox("Enabled")
+        self._spin_leave_filter_duration = QDoubleSpinBox()
+        self._spin_leave_filter_duration.setAccessibleName("Leave filter duration")
+        self._spin_leave_filter_duration.setRange(0.01, 60.0)
+        self._spin_leave_filter_duration.setDecimals(2)
+        self._spin_leave_filter_duration.setSingleStep(0.05)
+        self._spin_leave_filter_duration.setSuffix(" s")
+        self._spin_leave_filter_duration.setValue(0.2)
+        self._spin_leave_filter_duration.setEnabled(False)
+
+        self._compact_layout = QGridLayout()
+        self._compact_layout.setContentsMargins(0, 0, 0, 0)
+        self._compact_layout.setHorizontalSpacing(6)
+        self._compact_layout.setVerticalSpacing(6)
+        self._compact_layout.addWidget(self.checkbox_enabled, 0, 0)
+        self._add_field(0, 1, "ID", self.line_device_id)
+        self._add_field(0, 3, "Pin", self._line_pin)
+        self._add_field(1, 0, "Port", self._combo_port, field_column_span=2)
+        self._add_field(1, 3, "Baud", self._combo_baudrate)
+        self._add_field(2, 0, "Poll", self._line_poll_interval)
+        self._add_field(2, 2, "RFID Timeout", self._line_rfid_timeout)
+        self._add_field(3, 0, "Leave Filter", self._checkbox_leave_filter)
+        self._add_field(3, 2, "Duration", self._spin_leave_filter_duration)
+        self._compact_layout.setColumnStretch(2, 1)
+        self.layout_config.addRow(self._compact_layout)
+
+        self._checkbox_leave_filter.toggled.connect(
+            self._spin_leave_filter_duration.setEnabled
+        )
+
+    def _add_field(
+        self,
+        row: int,
+        label_column: int,
+        text: str,
+        field: QWidget,
+        *,
+        field_column_span: int = 1,
+    ) -> None:
+        label = QLabel(text)
+        label.setBuddy(field)
+        self._compact_layout.addWidget(label, row, label_column)
+        self._compact_layout.addWidget(
+            field,
+            row,
+            label_column + 1,
+            1,
+            field_column_span,
+        )
 
     def load_config(self, model: FusionContinuousDetectorModel) -> None:
         self.checkbox_enabled.setChecked(model.enabled)
@@ -46,6 +102,8 @@ class FusionDetectorCard(DeviceCard[FusionContinuousDetectorModel]):
         self._combo_baudrate.setCurrentText(str(model.baudrate))
         self._line_poll_interval.setText(str(model.poll_interval))
         self._line_rfid_timeout.setText(str(model.rfid_timeout))
+        self._checkbox_leave_filter.setChecked(model.beam_break_filter_enabled)
+        self._spin_leave_filter_duration.setValue(model.beam_break_filter_duration)
 
     @property
     def result(self) -> FusionContinuousDetectorModel:
@@ -57,4 +115,6 @@ class FusionDetectorCard(DeviceCard[FusionContinuousDetectorModel]):
             baudrate=int(self._combo_baudrate.currentData()),
             poll_interval=float(self._line_poll_interval.text()),
             rfid_timeout=float(self._line_rfid_timeout.text()),
+            beam_break_filter_enabled=self._checkbox_leave_filter.isChecked(),
+            beam_break_filter_duration=self._spin_leave_filter_duration.value(),
         )

--- a/src/mxbiflow/ui/components/device_card/device_card.py
+++ b/src/mxbiflow/ui/components/device_card/device_card.py
@@ -18,7 +18,12 @@ from ..card import CardFrame
 class DeviceCard[T](CardFrame):
     remove_requested = Signal()
 
-    def __init__(self, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        mount_base_fields: bool = True,
+    ) -> None:
         super().__init__(parent=parent, object_name="card")
 
         self.setContextMenuPolicy(Qt.ContextMenuPolicy.CustomContextMenu)
@@ -39,13 +44,14 @@ class DeviceCard[T](CardFrame):
         self.lable_enabled = QLabel("Enabled:")
         self.checkbox_enabled = QCheckBox()
         self.checkbox_enabled.setChecked(False)
-        self.layout_config.addRow(self.lable_enabled, self.checkbox_enabled)
 
         self.label_id = QLabel("Device ID:")
         self.line_device_id = QLineEdit("0")
         self.int_validator = QIntValidator(0, 1000, self)
         self.line_device_id.setValidator(self.int_validator)
-        self.layout_config.addRow(self.label_id, self.line_device_id)
+        if mount_base_fields:
+            self.layout_config.addRow(self.lable_enabled, self.checkbox_enabled)
+            self.layout_config.addRow(self.label_id, self.line_device_id)
 
     def _open_menu(self, position: QPoint) -> None:
         menu = QMenu(self)

--- a/tests/test_driver_factory.py
+++ b/tests/test_driver_factory.py
@@ -37,6 +37,15 @@ class DetectorModelTests(unittest.TestCase):
         with self.assertRaises(ValidationError):
             self.adapter.validate_python({"type": "standard_gate"})
 
+    def test_fusion_filter_defaults_and_validation(self) -> None:
+        model = FusionContinuousDetectorModel()
+
+        self.assertFalse(model.beam_break_filter_enabled)
+        self.assertEqual(model.beam_break_filter_duration, 0.2)
+
+        with self.assertRaises(ValidationError):
+            FusionContinuousDetectorModel(beam_break_filter_duration=0)
+
 
 class DetectorFactoryTests(unittest.TestCase):
     def test_builds_mock_detector(self) -> None:
@@ -81,6 +90,8 @@ class DetectorFactoryTests(unittest.TestCase):
             pin=17,
             poll_interval=0.5,
             rfid_timeout=0.1,
+            beam_break_filter_enabled=True,
+            beam_break_filter_duration=0.3,
         )
 
         result = _make_detector(config)
@@ -92,6 +103,8 @@ class DetectorFactoryTests(unittest.TestCase):
             sensor_type.return_value,
             poll_interval=0.5,
             rfid_timeout=0.1,
+            beam_break_filter_enabled=True,
+            beam_break_filter_duration=0.3,
         )
         self.assertIs(result, detector_type.return_value)
 

--- a/tests/test_fusion_continuous_detector.py
+++ b/tests/test_fusion_continuous_detector.py
@@ -1,0 +1,74 @@
+# pyright: reportPrivateUsage=false
+
+import unittest
+from unittest.mock import Mock
+
+from mxbiflow.driver.detector.detector import DetectorEvent
+from mxbiflow.driver.detector.fusion_continuous_detector import (
+    FusionContinuousDetector,
+    _Event,
+)
+
+
+class FusionContinuousDetectorFilterTests(unittest.TestCase):
+    def test_disabled_filter_emits_falling_edge_immediately(self) -> None:
+        sensor = Mock()
+        sensor.read.side_effect = [True, False]
+        detector = FusionContinuousDetector(Mock(), sensor)
+
+        self.assertEqual(detector._detect_edge(0.0), _Event.RISING_EDGE)
+        self.assertEqual(detector._detect_edge(0.01), _Event.FALLING_EDGE)
+
+    def test_enabled_filter_cancels_transient_clear_state(self) -> None:
+        sensor = Mock()
+        sensor.read.side_effect = [True, False, True, False, False, False]
+        detector = FusionContinuousDetector(
+            Mock(),
+            sensor,
+            beam_break_filter_enabled=True,
+            beam_break_filter_duration=0.2,
+        )
+
+        self.assertEqual(detector._detect_edge(0.0), _Event.RISING_EDGE)
+        self.assertIsNone(detector._detect_edge(0.01))
+        self.assertIsNone(detector._detect_edge(0.1))
+        self.assertIsNone(detector._detect_edge(0.2))
+        self.assertIsNone(detector._detect_edge(0.39))
+        self.assertEqual(detector._detect_edge(0.4), _Event.FALLING_EDGE)
+
+    def test_filtered_falling_edge_emits_one_leave_event(self) -> None:
+        sensor = Mock()
+        sensor.read.side_effect = [True, False, False, False]
+        detector = FusionContinuousDetector(
+            Mock(),
+            sensor,
+            beam_break_filter_enabled=True,
+            beam_break_filter_duration=0.2,
+        )
+        results = []
+        detector.register_event(DetectorEvent.ANIMAL_LEFT, results.append)
+
+        rising = detector._detect_edge(0.0)
+        self.assertEqual(rising, _Event.RISING_EDGE)
+        if rising is None:
+            self.fail("Expected a rising edge")
+        detector._dispatch(rising)
+        detector._dispatch(_Event.TIMEOUT)
+
+        self.assertIsNone(detector._detect_edge(0.1))
+        falling = detector._detect_edge(0.31)
+        self.assertEqual(falling, _Event.FALLING_EDGE)
+        if falling is None:
+            self.fail("Expected a falling edge")
+        detector._dispatch(falling)
+        self.assertIsNone(detector._detect_edge(0.5))
+
+        self.assertEqual(len(results), 1)
+
+    def test_rejects_non_positive_filter_duration(self) -> None:
+        with self.assertRaisesRegex(ValueError, "greater than 0"):
+            FusionContinuousDetector(Mock(), Mock(), beam_break_filter_duration=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fusion_detector_ui.py
+++ b/tests/test_fusion_detector_ui.py
@@ -1,0 +1,85 @@
+# pyright: reportPrivateUsage=false
+
+import os
+import unittest
+from unittest.mock import patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtCore import Qt
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QGridLayout
+
+from mxbiflow.driver.detector import FusionContinuousDetectorModel
+from mxbiflow.ui.components.device_card.detector.fusion_detector import (
+    FusionDetectorCard,
+)
+
+
+class FusionDetectorCardTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.app = QApplication.instance() or QApplication([])
+
+    def test_filter_configuration_round_trip(self) -> None:
+        card = FusionDetectorCard()
+        model = FusionContinuousDetectorModel(
+            beam_break_filter_enabled=True,
+            beam_break_filter_duration=0.35,
+        )
+
+        card.load_config(model)
+
+        self.assertTrue(card._checkbox_leave_filter.isChecked())
+        self.assertTrue(card._spin_leave_filter_duration.isEnabled())
+        self.assertAlmostEqual(card.result.beam_break_filter_duration, 0.35)
+        self.assertTrue(card.result.beam_break_filter_enabled)
+
+        card._checkbox_leave_filter.setChecked(False)
+
+        self.assertFalse(card._spin_leave_filter_duration.isEnabled())
+        self.assertFalse(card.result.beam_break_filter_enabled)
+
+    @patch(
+        "mxbiflow.ui.components.device_card.detector.fusion_detector.get_all_ports",
+        return_value=["/dev/ttyUSB9"],
+    )
+    def test_full_configuration_round_trip(self, _get_all_ports: object) -> None:
+        card = FusionDetectorCard()
+        model = FusionContinuousDetectorModel(
+            enabled=True,
+            id=7,
+            pin=13,
+            port="/dev/ttyUSB9",
+            baudrate=115200,
+            poll_interval=0.2,
+            rfid_timeout=0.08,
+            beam_break_filter_enabled=True,
+            beam_break_filter_duration=0.35,
+        )
+
+        card.load_config(model)
+
+        self.assertEqual(card.result, model)
+
+    def test_related_fields_are_grouped_into_four_rows(self) -> None:
+        card = FusionDetectorCard()
+
+        self.assertEqual(card.layout_config.rowCount(), 1)
+        self.assertEqual(card._compact_layout.rowCount(), 4)
+        self.assertGreaterEqual(card.minimumWidth(), 400)
+        self.assertIsInstance(card._compact_layout, QGridLayout)
+
+    def test_enabled_checkbox_can_be_clicked(self) -> None:
+        card = FusionDetectorCard()
+        card.show()
+        self.app.processEvents()
+
+        self.assertFalse(card.checkbox_enabled.isChecked())
+        QTest.mouseClick(card.checkbox_enabled, Qt.MouseButton.LeftButton)
+
+        self.assertTrue(card.checkbox_enabled.isChecked())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a configurable stable-clear beam-break filter to the fusion continuous detector
- wire the new options through the model, factory, and a compact four-row detector UI
- add regression coverage for detector timing, factory wiring, and UI interaction

## Validation

- `QT_QPA_PLATFORM=offscreen uv run --frozen python -m unittest discover -s tests` (132 passed)
- targeted `uv run --frozen pyright` for changed implementation and tests (0 errors)
- `uvx ruff format .`
- `uvx ruff check --fix .`
- `uvx ruff check .`