### PR TITLE
fix(session): :bug: persist animal training progress

### DIFF
--- a/src/mxbiflow/bootstrap.py
+++ b/src/mxbiflow/bootstrap.py
@@ -37,8 +37,12 @@ def init_gameloop(scene_manager: SceneManager, max_fps: int = 60) -> Game:
     """
     mxbi_config = ConfigStore(get_mxbi_config_path(), MXBIModel).value
     mxbi = build_mxbi(mxbi_config)
-    session_config = ConfigStore(get_config_session_path(), SessionConfig).value
-    session = init_session(session_config, mxbi_config)
+    session_config_store = ConfigStore(get_config_session_path(), SessionConfig)
+    session = init_session(
+        session_config_store.value,
+        mxbi_config,
+        config_store=session_config_store,
+    )
 
     animals_map = {
         animal.config.rfid_id: animal.config.name for animal in session.animals.values()
@@ -61,6 +65,8 @@ def build_mxbi(mxbi_config: MXBIModel) -> MXBI:
 def init_session(
     session_config: SessionConfig,
     mxbi_config: MXBIModel,
+    *,
+    config_store: ConfigStore[SessionConfig] | None = None,
 ) -> Session:
     store = RuntimeStateStore(get_runtime_state_path())
 
@@ -84,5 +90,7 @@ def init_session(
         state=SessionState(animals=animal_dict),
     )
     session.set_session_store(store)
+    if config_store is not None:
+        session.set_config_store(config_store)
 
     return session

--- a/src/mxbiflow/models/animal.py
+++ b/src/mxbiflow/models/animal.py
@@ -43,6 +43,15 @@ class AnimalConfig(BaseModel):
     # Ordered stage names for manual next/prev navigation; empty disables it.
     stage_order: tuple[str, ...] = ()
 
+    def with_progress(self, *, stage: str, level: int) -> AnimalConfig:
+        return AnimalConfig(
+            rfid_id=self.rfid_id,
+            name=self.name,
+            stage=stage,
+            level=level,
+            stage_order=self.stage_order,
+        )
+
 
 class AnimalBaseInfo(BaseModel):
     animal: str

--- a/src/mxbiflow/models/session.py
+++ b/src/mxbiflow/models/session.py
@@ -5,6 +5,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Protocol
 
 from pydantic import (
     BaseModel,
@@ -48,6 +49,21 @@ class SessionConfig(BaseModel):
 
     animals: tuple[AnimalConfig, ...] = ()
 
+    def with_animals(self, animals: tuple[AnimalConfig, ...]) -> SessionConfig:
+        return SessionConfig(
+            experimenter=self.experimenter,
+            reward_type=self.reward_type,
+            send_email=self.send_email,
+            sync_data=self.sync_data,
+            note=self.note,
+            default_scene=self.default_scene,
+            unknown_animal_as=self.unknown_animal_as,
+            fault_fallback=self.fault_fallback,
+            hide_cursor=self.hide_cursor,
+            fullscreen=self.fullscreen,
+            animals=animals,
+        )
+
     @model_validator(mode="after")
     def _validate_unknown_animal_as(self) -> SessionConfig:
         if not self.animals:
@@ -62,6 +78,13 @@ class SessionConfig(BaseModel):
         if self.unknown_animal_as not in animal_names:
             raise ValueError("unknown_animal_as must match a configured animal name")
         return self
+
+
+class SessionConfigStore(Protocol):
+    @property
+    def value(self) -> SessionConfig: ...
+
+    def save(self, data: SessionConfig | None = None) -> None: ...
 
 
 class SessionState(ContextState):
@@ -173,6 +196,7 @@ class Session(BaseModel):
     state: SessionState
 
     _session_store: RuntimeStateStore | None = PrivateAttr(default=None)
+    _config_store: SessionConfigStore | None = PrivateAttr(default=None)
     _snapshot_store: SessionSnapshotStore | None = PrivateAttr(default=None)
     _animal_snapshot_stores: dict[str, SessionSnapshotStore] = PrivateAttr(
         default_factory=dict
@@ -315,6 +339,9 @@ class Session(BaseModel):
     def set_session_store(self, store: RuntimeStateStore) -> None:
         self._session_store = store
 
+    def set_config_store(self, store: SessionConfigStore) -> None:
+        self._config_store = store
+
     def set_snapshot_store(self, store: SessionSnapshotStore) -> None:
         self._snapshot_store = store
 
@@ -406,6 +433,7 @@ class Session(BaseModel):
 
         animal.current_stage_name = stage.stage_name
         animal.stages.setdefault(stage.stage_name, stage)
+        self._persist_animal_progress(animal)
         self.checkpoint()
 
     @property
@@ -470,9 +498,12 @@ class Session(BaseModel):
         animal: str | None = None,
         stage: str | None = None,
     ) -> int:
+        animal_state = self._resolve_animal(animal)
         stage_state = self._resolve_stage(animal=animal, stage=stage)
         stage_state.level_trial_id = 0
         stage_state.level += 1
+        if stage_state is animal_state.current_stage:
+            self._persist_animal_progress(animal_state)
         self.checkpoint()
         return stage_state.level
 
@@ -482,14 +513,33 @@ class Session(BaseModel):
         animal: str | None = None,
         stage: str | None = None,
     ) -> int:
+        animal_state = self._resolve_animal(animal)
         stage_state = self._resolve_stage(animal=animal, stage=stage)
         if stage_state.level == 0:
             raise ValueError("level cannot be less than 0")
 
         stage_state.level_trial_id = 0
         stage_state.level -= 1
+        if stage_state is animal_state.current_stage:
+            self._persist_animal_progress(animal_state)
         self.checkpoint()
         return stage_state.level
+
+    def _persist_animal_progress(self, animal: Animal) -> None:
+        store = self._config_store
+        if store is None:
+            return
+
+        updated_animals = tuple(
+            animal_config.with_progress(
+                stage=animal.current_stage_name,
+                level=animal.current_stage.level,
+            )
+            if animal_config.name == animal.name
+            else animal_config
+            for animal_config in store.value.animals
+        )
+        store.save(store.value.with_animals(updated_animals))
 
     def get_context[T: BaseModel](self, key: str, context_type: type[T]) -> T | None:
         return self.state.get_context(key, context_type)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from pydantic import BaseModel, ValidationError
 
 from mxbiflow.bootstrap import init_session
+from mxbiflow.core.config_store import ConfigStore
 from mxbiflow.driver import MXBIModel
 from mxbiflow.models.animal import Animal, AnimalConfig, StageSnapshot, StageState
 from mxbiflow.models.session import (
@@ -33,6 +34,18 @@ class RecordingSnapshotStore(SessionSnapshotStore):
 
     def save(self, snapshot: Mapping[str, object]) -> None:
         self.snapshots.append(dict(snapshot))
+
+
+class RecordingConfigStore:
+    def __init__(self, config: SessionConfig) -> None:
+        self.value = config
+        self.saved: list[SessionConfig] = []
+
+    def save(self, data: SessionConfig | None = None) -> None:
+        if data is None:
+            return
+        self.value = data
+        self.saved.append(data)
 
 
 def make_session() -> Session:
@@ -164,6 +177,43 @@ class SessionModelTests(unittest.TestCase):
         )
         self.assertEqual(config.unknown_animal_as, animal.name)
 
+    def test_session_config_with_animals_returns_validated_copy(self) -> None:
+        animal = AnimalConfig(name="animal-1")
+        replacement = animal.with_progress(stage="stage_b", level=3)
+        config = SessionConfig(
+            experimenter="tester",
+            send_email=True,
+            sync_data=True,
+            note="note",
+            default_scene="default",
+            unknown_animal_as=animal.name,
+            fault_fallback="fallback",
+            hide_cursor=True,
+            fullscreen=True,
+            animals=(animal,),
+        )
+
+        updated = config.with_animals((replacement,))
+
+        self.assertEqual(updated.animals, (replacement,))
+        self.assertEqual(updated.experimenter, config.experimenter)
+        self.assertEqual(updated.reward_type, config.reward_type)
+        self.assertEqual(updated.send_email, config.send_email)
+        self.assertEqual(updated.sync_data, config.sync_data)
+        self.assertEqual(updated.note, config.note)
+        self.assertEqual(updated.default_scene, config.default_scene)
+        self.assertEqual(updated.unknown_animal_as, config.unknown_animal_as)
+        self.assertEqual(updated.fault_fallback, config.fault_fallback)
+        self.assertEqual(updated.hide_cursor, config.hide_cursor)
+        self.assertEqual(updated.fullscreen, config.fullscreen)
+        self.assertEqual(config.animals, (animal,))
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "unknown_animal_as must match",
+        ):
+            config.with_animals((AnimalConfig(name="animal-2"),))
+
     def test_legacy_unknown_animal_field_does_not_configure_mapping(self) -> None:
         animal = AnimalConfig(name="animal-1")
 
@@ -186,6 +236,28 @@ class SessionModelTests(unittest.TestCase):
 
         self.assertEqual(parsed.stage_order, ("stage_a", "stage_b"))
         self.assertEqual(AnimalConfig().stage_order, ())
+
+    def test_animal_config_with_progress_returns_validated_copy(self) -> None:
+        config = AnimalConfig(
+            rfid_id="rfid-1",
+            name="animal-1",
+            stage="stage_a",
+            level=2,
+            stage_order=("stage_a", "stage_b"),
+        )
+
+        updated = config.with_progress(stage="stage_b", level=3)
+
+        self.assertEqual(updated.stage, "stage_b")
+        self.assertEqual(updated.level, 3)
+        self.assertEqual(updated.rfid_id, config.rfid_id)
+        self.assertEqual(updated.name, config.name)
+        self.assertEqual(updated.stage_order, config.stage_order)
+        self.assertEqual(config.stage, "stage_a")
+        self.assertEqual(config.level, 2)
+
+        with self.assertRaises(ValidationError):
+            config.with_progress(stage="stage_b", level=-1)
 
     def test_bootstrap_reuses_animal_config(self) -> None:
         animal_config = AnimalConfig(
@@ -558,6 +630,86 @@ class SessionModelTests(unittest.TestCase):
             ),
             ExampleContext(value=4),
         )
+
+    def test_current_stage_progress_is_persisted_across_sessions(self) -> None:
+        with TemporaryDirectory() as directory:
+            config_path = Path(directory) / "config" / "session.json"
+            animal_config = AnimalConfig(
+                rfid_id="rfid-1",
+                name="animal-1",
+                stage="stage_a",
+                level=2,
+                stage_order=("stage_a", "stage_b"),
+            )
+            other_config = AnimalConfig(name="animal-2", stage="other", level=4)
+            config = SessionConfig(
+                unknown_animal_as=animal_config.name,
+                animals=(animal_config, other_config),
+            )
+            config_store = ConfigStore(config_path, SessionConfig)
+            config_store.save(config)
+            mxbi_config = MXBIModel(
+                backup_source_root_id="source",
+                backup_destination_root_id="destination",
+            )
+
+            with patch(
+                "mxbiflow.bootstrap.get_runtime_state_path",
+                return_value=Path(directory) / "runtime.json",
+            ):
+                session = init_session(
+                    config_store.value,
+                    mxbi_config,
+                    config_store=config_store,
+                )
+                session.set_current_animal("animal-1")
+                session.level_up()
+
+                persisted = ConfigStore(config_path, SessionConfig).value
+                self.assertEqual(persisted.animals[0].stage, "stage_a")
+                self.assertEqual(persisted.animals[0].level, 3)
+                self.assertEqual(persisted.animals[0].rfid_id, "rfid-1")
+                self.assertEqual(persisted.animals[0].stage_order, ("stage_a", "stage_b"))
+                self.assertEqual(persisted.animals[1], other_config)
+
+                session.go_next_stage()
+                session.level_up()
+
+                reloaded_store = ConfigStore(config_path, SessionConfig)
+                restarted = init_session(
+                    reloaded_store.value,
+                    mxbi_config,
+                    config_store=reloaded_store,
+                )
+
+            restarted_animal = restarted.animals["animal-1"]
+            self.assertEqual(restarted_animal.current_stage_name, "stage_b")
+            self.assertEqual(restarted_animal.current_stage.level, 1)
+
+    def test_only_successful_current_progress_changes_are_persisted(self) -> None:
+        session = make_session()
+        store = RecordingConfigStore(session.config)
+        session.set_config_store(store)
+        session.set_current_animal("animal-1")
+        animal = session.require_current_animal()
+        animal.stages["historical"] = StageState(
+            stage_name="historical",
+            initial_level=4,
+            level=4,
+        )
+
+        session.level_up(animal="animal-1", stage="historical")
+        self.assertEqual(store.saved, [])
+
+        animal.current_stage.level = 0
+        with self.assertRaisesRegex(ValueError, "less than 0"):
+            session.level_down()
+        self.assertEqual(store.saved, [])
+
+        session.level_up()
+        self.assertEqual(len(store.saved), 1)
+        self.assertEqual(store.value.animals[0].stage, animal.current_stage_name)
+        self.assertEqual(store.value.animals[0].level, 1)
 
 
 class StageNavigationTests(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -545,7 +545,7 @@ wheels = [
 
 [[package]]
 name = "mxbiflow"
-version = "0.3.20"
+version = "0.3.21"
 source = { editable = "." }
 dependencies = [
     { name = "gpiozero" },


### PR DESCRIPTION
## Summary
- persist current animal stage and level changes to the session configuration
- inject the session config store through bootstrap
- add validated immutable update helpers for animal and session configuration

## Validation
- `uv run python -m unittest discover -s tests` (135 tests passed)
- `uvx ruff check src/mxbiflow/models/session.py tests/test_session.py`
- `uv run pyright src/mxbiflow/models/animal.py src/mxbiflow/models/session.py tests/test_session.py`
- `git diff --check`