### PR TITLE
feat(idle): :sparkles: add manual control buttons

### DIFF
--- a/src/mxbiflow/scene/idle/idle.py
+++ b/src/mxbiflow/scene/idle/idle.py
@@ -2,11 +2,15 @@ from dataclasses import dataclass
 from random import choice
 from typing import ClassVar
 
-from pygame import Event, Rect, Surface, image, transform
+from pygame import MOUSEBUTTONDOWN, QUIT, Event, Rect, Surface, event, image, transform
+from pygame.sprite import Group
 
-from ...assets import APPLE_IMAGES, create_background
+from ...assets import APPLE_IMAGES, Corner, CornerButton, create_background
 from ...core.context import get_mxbiflow
 from ..scene import Scene
+
+_BORDER_WIDTH = 40
+_MANUAL_REWARD_DURATION_MS = 1_000
 
 
 @dataclass
@@ -26,6 +30,7 @@ class IDLE(Scene):
         self._screen_size = self._mxbiflow.mxbi.screen_size
         self._background = create_background(
             (self._screen_size.width, self._screen_size.height),
+            border_width=_BORDER_WIDTH,
         )
         self._pos = ((self._screen_size.width // 4) * 3, self._screen_size.height // 2)
         self._vstimulus_size = self._screen_size.width // 2 * 0.75
@@ -45,6 +50,22 @@ class IDLE(Scene):
         ]
 
         self._asset = choice(self._assets)
+        self._control_buttons = Group(
+            CornerButton(
+                Corner.TOP_RIGHT,
+                _BORDER_WIDTH // 2,
+                _BORDER_WIDTH,
+                self._give_manual_reward,
+                color=(0, 160, 0),
+            ),
+            CornerButton(
+                Corner.BOTTOM_RIGHT,
+                _BORDER_WIDTH // 2,
+                _BORDER_WIDTH,
+                self._request_game_quit,
+                color=(200, 0, 0),
+            ),
+        )
 
     def start(self) -> None:
         self._running = True
@@ -52,10 +73,22 @@ class IDLE(Scene):
     def quit(self) -> None:
         self._running = False
 
-    def handle_event(self, event: Event) -> None: ...
+    def handle_event(self, event: Event) -> None:
+        if event.type == MOUSEBUTTONDOWN and event.button == 1:
+            any(button.handle_event(event) for button in self._control_buttons)
 
-    def update(self, dt_s: float) -> None: ...
+    def update(self, dt_s: float) -> None:
+        self._control_buttons.update(dt_s)
 
     def draw(self, screen: Surface) -> None:
         screen.blit(self._background, (0, 0))
         screen.blit(self._asset.image, self._asset.rect)
+        for button in self._control_buttons:
+            button.layout(screen)
+        self._control_buttons.draw(screen)
+
+    def _give_manual_reward(self) -> None:
+        self._mxbiflow.mxbi.rewarder.give_reward(_MANUAL_REWARD_DURATION_MS)
+
+    def _request_game_quit(self) -> None:
+        event.post(Event(QUIT))

--- a/tests/test_idle.py
+++ b/tests/test_idle.py
@@ -1,0 +1,61 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from pygame import MOUSEBUTTONDOWN, QUIT, Event, Surface
+
+from mxbiflow.scene.idle.idle import IDLE
+
+
+class IDLEControlButtonTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.rewarder = Mock()
+        mxbi = SimpleNamespace(
+            screen_size=SimpleNamespace(width=200, height=100),
+            rewarder=self.rewarder,
+        )
+        context = SimpleNamespace(mxbi=mxbi)
+        loaded_image = Mock()
+        loaded_image.convert_alpha.return_value = Surface((10, 10))
+
+        with (
+            patch("mxbiflow.scene.idle.idle.get_mxbiflow", return_value=context),
+            patch("mxbiflow.scene.idle.idle.image.load", return_value=loaded_image),
+        ):
+            self.scene = IDLE()
+
+        self.screen = Surface((200, 100))
+        self.scene.draw(self.screen)
+
+    @patch("mxbiflow.scene.idle.idle.event.post")
+    def test_control_buttons_trigger_reward_and_quit(self, post: Mock) -> None:
+        self.scene.handle_event(
+            Event(MOUSEBUTTONDOWN, button=1, pos=(190, 10)),
+        )
+        self.scene.handle_event(
+            Event(MOUSEBUTTONDOWN, button=1, pos=(190, 90)),
+        )
+
+        self.rewarder.give_reward.assert_called_once_with(1_000)
+        posted_event = post.call_args.args[0]
+        self.assertEqual(posted_event.type, QUIT)
+
+    @patch("mxbiflow.scene.idle.idle.event.post")
+    def test_other_clicks_do_not_trigger_controls(self, post: Mock) -> None:
+        self.scene.handle_event(
+            Event(MOUSEBUTTONDOWN, button=1, pos=(100, 50)),
+        )
+        self.scene.handle_event(
+            Event(MOUSEBUTTONDOWN, button=3, pos=(190, 10)),
+        )
+
+        self.rewarder.give_reward.assert_not_called()
+        post.assert_not_called()
+
+    def test_draw_places_buttons_in_expected_corners(self) -> None:
+        self.assertEqual(self.screen.get_at((190, 10)), (0, 160, 0, 255))
+        self.assertEqual(self.screen.get_at((190, 90)), (200, 0, 0, 255))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a top-right manual reward button to the idle scene with a 1-second default duration
- add a bottom-right quit button that posts a pygame QUIT event
- add coverage for control actions, ignored clicks, and button placement

## Verification
- uv run python -m unittest discover -s tests -v (138 passed)
- uvx ruff check src/mxbiflow/scene/idle/idle.py tests/test_idle.py
- uv run pyright src/mxbiflow/scene/idle/idle.py tests/test_idle.py
- uvx ruff format --check src/mxbiflow/scene/idle/idle.py tests/test_idle.py
- git diff --check